### PR TITLE
Skip .npmrc creation in GitHub Actions when running on Dependabot fork

### DIFF
--- a/.github/workflows/armory.yml
+++ b/.github/workflows/armory.yml
@@ -58,7 +58,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Add private .npmrc
+      - name: Add .npmrc
+        if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
         run: echo "${{ secrets.NPMRC }}" > .npmrc
 
       - name: Install node.js

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -30,7 +30,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Add private .npmrc
+      - name: Add .npmrc
+        if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
         run: echo "${{ secrets.NPMRC }}" > .npmrc
 
       - name: Install node.js

--- a/.github/workflows/policy-engine.yml
+++ b/.github/workflows/policy-engine.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Add private .npmrc
+      - name: Add .npmrc
+        if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
         run: echo "${{ secrets.NPMRC }}" > .npmrc
 
       - name: Install node.js

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Add private .npmrc
+      - name: Add .npmrc
+        if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
         run: echo "${{ secrets.NPMRC }}" > .npmrc
 
       - name: Install node.js


### PR DESCRIPTION
This PR attempts to address the NPM 401 issue with GitHub Actions missing proper secrets on Dependabot branches. It's not critical, but it's adding friction to the code maintenance.

Since Dependabot changes run in a fork, it doesn't have access to some secrets. We could introduce the secrets, but I don't believe we need them anymore, so I'd rather just drop them.

<img width="922" alt="image" src="https://github.com/narval-xyz/armory/assets/3832154/0d9410ce-cf88-4fd9-8792-c8ce23ff504a">