### PR TITLE
Fix optional load of the @narval-xyz/armory-mpc-module on non-authenticated NPM

### DIFF
--- a/apps/armory/src/policy-engine/core/util/armory-mpc-module.util.ts
+++ b/apps/armory/src/policy-engine/core/util/armory-mpc-module.util.ts
@@ -1,0 +1,30 @@
+import { HttpStatus } from '@nestjs/common'
+import { ApplicationException } from '../../../shared/exception/application.exception'
+
+export type FinalizeEcdsaJwtSignature = (jwts: string[]) => Promise<string>
+
+let finalizeEcdsaJwtSignature: FinalizeEcdsaJwtSignature | undefined
+
+export const loadFinalizeEcdsaJwtSignature = (): FinalizeEcdsaJwtSignature | void => {
+  if (finalizeEcdsaJwtSignature) {
+    return finalizeEcdsaJwtSignature
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const module = require('@narval-xyz/armory-mpc-module')
+
+    if (module.finalizeEcdsaJwtSignature) {
+      finalizeEcdsaJwtSignature = module.finalizeEcdsaJwtSignature
+      return module.finalizeEcdsaJwtSignature
+    }
+
+    throw new ApplicationException({
+      message: 'Function finalizeEcdsaJwtSignature not found in @narval-xyz/armory-mpc-module',
+      suggestedHttpStatusCode: HttpStatus.INTERNAL_SERVER_ERROR
+    })
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn('[Armory] Unable to lazy load finalizeEcdsaJwtSignature from @narval-xyz/armory-mpc-module')
+  }
+}

--- a/apps/policy-engine/src/engine/core/factory/signing-service.factory.ts
+++ b/apps/policy-engine/src/engine/core/factory/signing-service.factory.ts
@@ -1,7 +1,28 @@
 import { ConfigService } from '@narval/config-module'
+import { HttpStatus } from '@nestjs/common'
 import { Config } from '../../../policy-engine.config'
+import { ApplicationException } from '../../../shared/exception/application.exception'
 import { SimpleSigningService } from '../service/signing-basic.service'
 import { SigningService } from '../service/signing.service.interface'
+
+const loadArmoryMpcSigningService = () => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const module = require('@narval-xyz/armory-mpc-module')
+
+    if (module.ArmoryMpcSigningService) {
+      return module.ArmoryMpcSigningService
+    }
+
+    throw new ApplicationException({
+      message: 'Function finalizeEcdsaJwtSignature not found in @narval-xyz/armory-mpc-module',
+      suggestedHttpStatusCode: HttpStatus.INTERNAL_SERVER_ERROR
+    })
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn('[Armory] Unable to lazy load finalizeEcdsaJwtSignature from @narval-xyz/armory-mpc-module')
+  }
+}
 
 export const signingServiceFactory = async (configService: ConfigService<Config>): Promise<SigningService> => {
   const protocol = configService.get('signingProtocol')
@@ -17,13 +38,12 @@ export const signingServiceFactory = async (configService: ConfigService<Config>
       throw new Error('Missing TSM config')
     }
 
-    try {
-      const { ArmoryMpcSigningService } = await import('@narval-xyz/armory-mpc-module')
+    const ArmoryMpcSigningService = loadArmoryMpcSigningService()
 
-      return new ArmoryMpcSigningService(tsm)
-    } catch {
-      throw new Error('Unable to lazy load @narval-xyz/armory-mpc-module dependency')
-    }
+    // TODO: (@wcalderipe, 12/07/24) The ArmoryMpcSigningService has any type.
+    // How to ensure type-safety in a optional module since importing the type
+    // is impossible when the package isn't installed?
+    return new ArmoryMpcSigningService(tsm)
   }
 
   throw new Error(`Missing implementation for signing protocol: ${protocol}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -21614,8 +21614,8 @@
     },
     "node_modules/@narval-xyz/armory-mpc-module": {
       "version": "0.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@narval-xyz/armory-mpc-module/0.0.1/9bb685ee6adb956b344890f07b1aee99077ed6fa",
-      "integrity": "sha512-389KIpAzzEmcR0vkcyeHas+IvsFTCPNvTPolrSa5UwPBgTpHm5b7Fk0MlHVx6yJy9y9XKIvo4MkWhx8T5Ym2jg==",
+      "resolved": "https://registry.npmjs.org/@narval-xyz/armory-mpc-module/-/armory-mpc-module-0.0.1.tgz",
+      "integrity": "sha512-jAUKXB4tf5KgcNeqpcpVNzivvB4IiOMKpVufdhaRx+JHQDSxfCkFYcghtoWavZGA5csryrGMFHwPUZnA7q594g==",
       "bundleDependencies": [
         "@narval-xyz/armory-sdk"
       ],
@@ -27314,9 +27314,9 @@
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz",
-      "integrity": "sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
       "dependencies": {
         "merge-options": "^3.0.4"
       },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "@faker-js/faker": "8.4.1",
     "@nestjs/testing": "10.3.9",
     "@nx/devkit": "19.2.3",
-    "@nx/eslint-plugin": "19.3.2",
     "@nx/eslint": "19.3.2",
+    "@nx/eslint-plugin": "19.3.2",
     "@nx/jest": "19.2.0",
     "@nx/js": "19.2.0",
     "@nx/nest": "19.2.0",
@@ -133,10 +133,10 @@
     "winston-transport": "4.7.0",
     "zod": "3.23.8"
   },
-  "nx": {
-    "includedScripts": []
-  },
   "optionalDependencies": {
     "@narval-xyz/armory-mpc-module": "0.0.1"
+  },
+  "nx": {
+    "includedScripts": []
   }
 }


### PR DESCRIPTION
This PR fixes the optional loading of the `@narval-xyz/armory-mpc-module` for non-authenticated NPM usage, allowing developers outside Narval to use the repository in a non-MPC environment.

As a trade-off, we lose some type-safety by swapping `async import` with `require`. The issue with `async import` is that TypeScript attempts to read the type even when the package isn't installed, which throws a compile error.

## How it was tested?

I manually ran the SDK user journey test against a local stack using MPC as the signing method.

```bash
npx jest --config packages/armory-sdk/jest.e2e.ts packages/armory-sdk/src/lib/__test__/e2e/user-journeys.spec.ts
```