### PR TITLE
typed data support

### DIFF
--- a/apps/armory/src/__test__/fixture/authorization-request.fixture.ts
+++ b/apps/armory/src/__test__/fixture/authorization-request.fixture.ts
@@ -49,7 +49,7 @@ export const generateSignTransactionRequest = (partial?: Partial<SignTransaction
   }
 }
 
-export const generateAuthorizationRequest = (partial?: Partial<AuthorizationRequest>): AuthorizationRequest => {
+export const generateAuthorizationRequest = (partial?: Partial<AuthorizationRequest>) => {
   const fixture = new Fixture()
     .extend([hexGenerator, addressGenerator, chainIdGenerator])
     .fromSchema(authorizationRequestSchema)

--- a/apps/armory/src/__test__/fixture/authorization-request.fixture.ts
+++ b/apps/armory/src/__test__/fixture/authorization-request.fixture.ts
@@ -49,7 +49,7 @@ export const generateSignTransactionRequest = (partial?: Partial<SignTransaction
   }
 }
 
-export const generateAuthorizationRequest = (partial?: Partial<AuthorizationRequest>) => {
+export const generateAuthorizationRequest = (partial?: Partial<AuthorizationRequest>): AuthorizationRequest => {
   const fixture = new Fixture()
     .extend([hexGenerator, addressGenerator, chainIdGenerator])
     .fromSchema(authorizationRequestSchema)

--- a/apps/armory/src/orchestration/__test__/e2e/authorization-request.spec.ts
+++ b/apps/armory/src/orchestration/__test__/e2e/authorization-request.spec.ts
@@ -141,8 +141,6 @@ describe('Authorization Request', () => {
         request: req
       }
 
-      Eip712TypedData.parse(payload.request.typedData)
-
       const { status, body } = await request(app.getHttpServer())
         .post(ENDPOINT)
         .set(REQUEST_HEADER_CLIENT_ID, client.id)

--- a/apps/armory/src/orchestration/orchestration.constant.ts
+++ b/apps/armory/src/orchestration/orchestration.constant.ts
@@ -8,8 +8,8 @@ import {
   readSignRawSchema
 } from './persistence/schema/sign-message.schema'
 import { createSignTransactionSchema, readSignTransactionSchema } from './persistence/schema/sign-transaction.schema'
-import { createSignUserOperationSchema, readSignUserOperationSchema } from './persistence/schema/sign-userop.schema'
 import { createSignTypedDataSchema, readSignTypedDataSchema } from './persistence/schema/sign-typed-data.schema'
+import { createSignUserOperationSchema, readSignUserOperationSchema } from './persistence/schema/sign-userop.schema'
 
 type ActionRequestConfig = {
   action: SupportedAction

--- a/apps/armory/src/orchestration/orchestration.constant.ts
+++ b/apps/armory/src/orchestration/orchestration.constant.ts
@@ -9,6 +9,7 @@ import {
 } from './persistence/schema/sign-message.schema'
 import { createSignTransactionSchema, readSignTransactionSchema } from './persistence/schema/sign-transaction.schema'
 import { createSignUserOperationSchema, readSignUserOperationSchema } from './persistence/schema/sign-userop.schema'
+import { createSignTypedDataSchema, readSignTypedDataSchema } from './persistence/schema/sign-typed-data.schema'
 
 type ActionRequestConfig = {
   action: SupportedAction
@@ -46,6 +47,16 @@ export const ACTION_REQUEST = new Map<Action, ActionRequestConfig>([
       schema: {
         read: readSignRawSchema,
         create: createSignRawSchema
+      }
+    }
+  ],
+  [
+    Action.SIGN_TYPED_DATA,
+    {
+      action: Action.SIGN_TYPED_DATA,
+      schema: {
+        read: readSignTypedDataSchema,
+        create: createSignTypedDataSchema
       }
     }
   ],

--- a/apps/armory/src/orchestration/persistence/decode/__test__/unit/authorization-request.decode.spec.ts
+++ b/apps/armory/src/orchestration/persistence/decode/__test__/unit/authorization-request.decode.spec.ts
@@ -92,4 +92,82 @@ describe('decodeAuthorizationRequest', () => {
       }).toThrow(DecodeAuthorizationRequestException)
     })
   })
+
+  describe('sign typed data', () => {
+    it('decodes a sign typed data authorization request with serialized message successfully', () => {
+      const validModel = {
+        ...sharedModel,
+        action: Action.SIGN_TYPED_DATA,
+        request: {
+          action: Action.SIGN_TYPED_DATA,
+          nonce: '99',
+          resourceId: '440b486a-8807-49d8-97a1-24c2920730ed',
+          typedData: {
+            types: {
+              EIP712Domain: [
+                { name: 'name', type: 'string' },
+                { name: 'version', type: 'string' },
+                { name: 'chainId', type: 'uint256' },
+                { name: 'verifyingContract', type: 'address' }
+              ],
+              Person: [
+                { name: 'name', type: 'string' },
+                { name: 'wallet', type: 'address' }
+              ]
+            },
+            primaryType: 'Person',
+            domain: {
+              name: 'Ether Mail',
+              version: '1',
+              chainId: 1,
+              verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
+            },
+            message: JSON.stringify({ name: 'Bob', wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' })
+          }
+        }
+      }
+
+      expect(() => {
+        decodeAuthorizationRequest(validModel)
+      }).not.toThrow(DecodeAuthorizationRequestException)
+    })
+
+    it('throws DecodeAuthorizationRequestException if message string is not a valid json', () => {
+      const invalidModel = {
+        ...sharedModel,
+        action: Action.SIGN_TYPED_DATA,
+        request: {
+          action: Action.SIGN_TYPED_DATA,
+          nonce: '99',
+          resourceId: '440b486a-8807-49d8-97a1-24c2920730ed',
+          typedData: {
+            types: {
+              EIP712Domain: [
+                { name: 'name', type: 'string' },
+                { name: 'version', type: 'string' },
+                { name: 'chainId', type: 'uint256' },
+                { name: 'verifyingContract', type: 'address' }
+              ],
+              Person: [
+                { name: 'name', type: 'string' },
+                { name: 'wallet', type: 'address' }
+              ]
+            },
+            primaryType: 'Person',
+            domain: {
+              name: 'Ether Mail',
+              version: '1',
+              chainId: 1,
+              verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
+            },
+            message: 'not-a-valid-json'
+          }
+        }
+      }
+
+      expect(() => {
+        decodeAuthorizationRequest(invalidModel)
+      }).toThrow(DecodeAuthorizationRequestException)
+    })
+  })
 })

--- a/apps/armory/src/orchestration/persistence/schema/request.schema.ts
+++ b/apps/armory/src/orchestration/persistence/schema/request.schema.ts
@@ -10,8 +10,8 @@ import {
   readSignTransactionSchema
 } from '../../persistence/schema/sign-transaction.schema'
 import { createGrantPermissionSchema, readGrantPermissionSchema } from './grant-permission.schema'
-import { createSignUserOperationSchema, readSignUserOperationSchema } from './sign-userop.schema'
 import { createSignTypedDataSchema, readSignTypedDataSchema } from './sign-typed-data.schema'
+import { createSignUserOperationSchema, readSignUserOperationSchema } from './sign-userop.schema'
 
 export const readRequestSchema = z.discriminatedUnion('action', [
   readSignTransactionSchema,

--- a/apps/armory/src/orchestration/persistence/schema/request.schema.ts
+++ b/apps/armory/src/orchestration/persistence/schema/request.schema.ts
@@ -11,13 +11,15 @@ import {
 } from '../../persistence/schema/sign-transaction.schema'
 import { createGrantPermissionSchema, readGrantPermissionSchema } from './grant-permission.schema'
 import { createSignUserOperationSchema, readSignUserOperationSchema } from './sign-userop.schema'
+import { createSignTypedDataSchema, readSignTypedDataSchema } from './sign-typed-data.schema'
 
 export const readRequestSchema = z.discriminatedUnion('action', [
   readSignTransactionSchema,
   readSignMessageSchema,
   readSignRawSchema,
   readGrantPermissionSchema,
-  readSignUserOperationSchema
+  readSignUserOperationSchema,
+  readSignTypedDataSchema
 ])
 
 export const createRequestSchema = z.discriminatedUnion('action', [
@@ -25,5 +27,6 @@ export const createRequestSchema = z.discriminatedUnion('action', [
   createSignMessageSchema,
   createGrantPermissionSchema,
   createSignRawSchema,
-  createSignUserOperationSchema
+  createSignUserOperationSchema,
+  createSignTypedDataSchema
 ])

--- a/apps/armory/src/orchestration/persistence/schema/sign-message.schema.ts
+++ b/apps/armory/src/orchestration/persistence/schema/sign-message.schema.ts
@@ -5,7 +5,7 @@ export const readSignMessageSchema = z.object({
   action: z.literal(Action.SIGN_MESSAGE),
   nonce: z.string(),
   resourceId: z.string(),
-  message: z.string()
+  message: z.union([z.string(), z.object({ raw: hexSchema })])
 })
 
 export const readSignRawSchema = z.object({

--- a/apps/armory/src/orchestration/persistence/schema/sign-typed-data.schema.ts
+++ b/apps/armory/src/orchestration/persistence/schema/sign-typed-data.schema.ts
@@ -1,0 +1,11 @@
+import { Action, SerializedEip712TypedData } from '@narval/policy-engine-shared'
+import { z } from 'zod'
+
+export const createSignTypedDataSchema = z.object({
+  action: z.literal(Action.SIGN_TYPED_DATA),
+  nonce: z.string(),
+  resourceId: z.string(),
+  typedData: SerializedEip712TypedData
+})
+
+export const readSignTypedDataSchema = createSignTypedDataSchema

--- a/apps/armory/src/orchestration/persistence/schema/sign-typed-data.schema.ts
+++ b/apps/armory/src/orchestration/persistence/schema/sign-typed-data.schema.ts
@@ -1,4 +1,4 @@
-import { Action, SerializedEip712TypedData } from '@narval/policy-engine-shared'
+import { Action, Eip712TypedData, SerializedEip712TypedData } from '@narval/policy-engine-shared'
 import { z } from 'zod'
 
 export const createSignTypedDataSchema = z.object({
@@ -8,4 +8,6 @@ export const createSignTypedDataSchema = z.object({
   typedData: SerializedEip712TypedData
 })
 
-export const readSignTypedDataSchema = createSignTypedDataSchema
+export const readSignTypedDataSchema = createSignTypedDataSchema.extend({
+  typedData: Eip712TypedData
+})

--- a/packages/armory-sdk/src/lib/http/client/auth/api.ts
+++ b/packages/armory-sdk/src/lib/http/client/auth/api.ts
@@ -244,10 +244,10 @@ export interface AuthorizationRequestDtoRequestOneOf2TypedData {
     'primaryType': string;
     /**
      * 
-     * @type {{ [key: string]: any; }}
+     * @type {AuthorizationRequestDtoRequestOneOf2TypedDataMessage}
      * @memberof AuthorizationRequestDtoRequestOneOf2TypedData
      */
-    'message': { [key: string]: any; };
+    'message': AuthorizationRequestDtoRequestOneOf2TypedDataMessage;
 }
 /**
  * 
@@ -286,6 +286,12 @@ export interface AuthorizationRequestDtoRequestOneOf2TypedDataDomain {
      */
     'salt'?: any;
 }
+/**
+ * @type AuthorizationRequestDtoRequestOneOf2TypedDataMessage
+ * @export
+ */
+export type AuthorizationRequestDtoRequestOneOf2TypedDataMessage = string | { [key: string]: any; };
+
 /**
  * 
  * @export

--- a/packages/armory-sdk/src/lib/http/client/vault/api.ts
+++ b/packages/armory-sdk/src/lib/http/client/vault/api.ts
@@ -807,10 +807,10 @@ export interface SignRequestDtoRequestOneOf2TypedData {
     'primaryType': string;
     /**
      * 
-     * @type {{ [key: string]: any; }}
+     * @type {SignRequestDtoRequestOneOf2TypedDataMessage}
      * @memberof SignRequestDtoRequestOneOf2TypedData
      */
-    'message': { [key: string]: any; };
+    'message': SignRequestDtoRequestOneOf2TypedDataMessage;
 }
 /**
  * 
@@ -849,6 +849,12 @@ export interface SignRequestDtoRequestOneOf2TypedDataDomain {
      */
     'salt'?: any;
 }
+/**
+ * @type SignRequestDtoRequestOneOf2TypedDataMessage
+ * @export
+ */
+export type SignRequestDtoRequestOneOf2TypedDataMessage = string | { [key: string]: any; };
+
 /**
  * 
  * @export

--- a/packages/policy-engine-shared/src/lib/type/action.type.ts
+++ b/packages/policy-engine-shared/src/lib/type/action.type.ts
@@ -93,7 +93,7 @@ export const Eip712TypedData = z.object({
   primaryType: z.string(),
   message: z.union([z.record(z.unknown()), z.string()]).transform((val) => {
     if (typeof val === 'string') {
-      return JSON.parse(val)
+      return JSON.parse(val) as Record<string, unknown>
     }
     return val
   })

--- a/packages/policy-engine-shared/src/lib/type/action.type.ts
+++ b/packages/policy-engine-shared/src/lib/type/action.type.ts
@@ -91,12 +91,16 @@ export const Eip712TypedData = z.object({
     )
   ),
   primaryType: z.string(),
-  message: z.union([z.record(z.unknown()), z.string()]).transform((val) => {
+  message: z.preprocess((val) => {
     if (typeof val === 'string') {
-      return JSON.parse(val) as Record<string, unknown>
+      try {
+        return JSON.parse(val)
+      } catch (error) {
+        return val
+      }
     }
     return val
-  })
+  }, z.record(z.unknown()))
 })
 export type Eip712TypedData = z.infer<typeof Eip712TypedData>
 

--- a/packages/policy-engine-shared/src/lib/type/action.type.ts
+++ b/packages/policy-engine-shared/src/lib/type/action.type.ts
@@ -91,9 +91,22 @@ export const Eip712TypedData = z.object({
     )
   ),
   primaryType: z.string(),
-  message: z.record(z.unknown())
+  message: z.union([z.record(z.unknown()), z.string()]).transform((val) => {
+    if (typeof val === 'string') {
+      return JSON.parse(val)
+    }
+    return val
+  })
 })
 export type Eip712TypedData = z.infer<typeof Eip712TypedData>
+
+export const SerializedEip712TypedData = Eip712TypedData.transform((val) => {
+  return {
+    ...val,
+    message: JSON.stringify(val.message)
+  }
+})
+export type SerializedEip712TypedData = z.infer<typeof SerializedEip712TypedData>
 
 export const SignTransactionAction = BaseAction.merge(
   z.object({

--- a/packages/policy-engine-shared/src/lib/type/authorization-server.type.ts
+++ b/packages/policy-engine-shared/src/lib/type/authorization-server.type.ts
@@ -29,6 +29,7 @@ export const SupportedAction = {
   SIGN_RAW: Action.SIGN_RAW,
   SIGN_MESSAGE: Action.SIGN_MESSAGE,
   SIGN_USER_OPERATION: Action.SIGN_USER_OPERATION,
+  SIGN_TYPED_DATA: Action.SIGN_TYPED_DATA,
   GRANT_PERMISSION: Action.GRANT_PERMISSION
 } as const
 export type SupportedAction = (typeof SupportedAction)[keyof typeof SupportedAction]


### PR DESCRIPTION
### Support Typed Data in Auth Server

Auth server was not accepting Typed Data as valid Request. Also, AuthServer stores all requests in a Postgresql DB. So this PR does three things:
- Adds TypedData as a valid input
- Changed EIP712TypedData schema so that it automatically parses message field back to an object if its a string
- Added a SerializedEIP712TypedData schema that will serialize message into a string in AuthServer upon receiving an Authorization Request.
