### PR TITLE
SignMessage can be { raw: hex }

### DIFF
--- a/apps/armory/src/orchestration/persistence/decode/__test__/unit/authorization-request.decode.spec.ts
+++ b/apps/armory/src/orchestration/persistence/decode/__test__/unit/authorization-request.decode.spec.ts
@@ -91,6 +91,23 @@ describe('decodeAuthorizationRequest', () => {
         decodeAuthorizationRequest(invalidModel)
       }).toThrow(DecodeAuthorizationRequestException)
     })
+
+    it('decodes a raw message successfully', () => {
+      const validModel = {
+        ...sharedModel,
+        action: Action.SIGN_MESSAGE,
+        request: {
+          action: Action.SIGN_MESSAGE,
+          nonce: '99',
+          resourceId: '440b486a-8807-49d8-97a1-24c2920730ed',
+          message: { raw: '0xdeadbeef' }
+        }
+      }
+
+      expect(() => {
+        decodeAuthorizationRequest(validModel)
+      }).not.toThrow(DecodeAuthorizationRequestException)
+    })
   })
 
   describe('sign typed data', () => {


### PR DESCRIPTION
This PR adds the unit test to cover the bugfix that was added in a[ previous PR](https://github.com/narval-xyz/armory/commit/88ed7db9bd35137c48b1a7be9eaf3e295bbf5319#diff-753c21adac9903c86cb01b1beadeef81e9ca925c12de6c22a8b9044093bd3ae6L8).

It enforces that the Auth Server accepts message: string or message: { raw: hex } for `SignMessage` request. Thus, we are viem compatible