### PR TITLE
Remove .npmrc creation step to avoid configuration conflict in the package publish pipeline

### DIFF
--- a/.github/workflows/packages-publish.yml
+++ b/.github/workflows/packages-publish.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Add private .npmrc
-        run: echo "${{ secrets.NPMRC }}" > .npmrc
-
       - name: Install node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This PR attempts to fix the package publish pipeline that's failing due to a 403 in the NPM publish step (see https://github.com/narval-xyz/armory/actions/runs/9970334505/job/27549012424). The publishing registry should always be NPM and the token must always come from the `NPM_AUTH_TOKEN` secret.

I don't believe we need the `.npmrc` creation step anymore after #421 