### PR TITLE
Fixes in Devtool & using Approvals

### DIFF
--- a/apps/devtool/src/app/_components/Playground.tsx
+++ b/apps/devtool/src/app/_components/Playground.tsx
@@ -3,7 +3,7 @@
 import { faArrowsRotate, faFileSignature } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { AuthorizationResponse, Evaluate, SendEvaluationResponse, SignatureRequest } from '@narval/armory-sdk'
-import { AuthorizationRequest, EvaluationRequest, hexSchema } from '@narval/policy-engine-shared'
+import { AuthorizationRequest, EvaluationRequest, hexSchema, stringify } from '@narval/policy-engine-shared'
 import { FC, ReactNode, useEffect, useState } from 'react'
 import NarButton from '../_design-system/NarButton'
 import useStore from '../_hooks/useStore'
@@ -57,15 +57,15 @@ const Playground: FC<PlaygroundProps> = ({ title, configModal, errors, authorize
     switch (template) {
       case Template.ERC20:
         setResponseEditor(undefined)
-        setRequestEditor(JSON.stringify(await erc20(), null, 2))
+        setRequestEditor(stringify(await erc20(), null, 2))
         break
       case Template.SPENDING_LIMITS:
         setResponseEditor(undefined)
-        setRequestEditor(JSON.stringify(await spendingLimits(), null, 2))
+        setRequestEditor(stringify(await spendingLimits(), null, 2))
         break
       case Template.GRANT_PERMISSION:
         setResponseEditor(undefined)
-        setRequestEditor(JSON.stringify(await grantPermission(), null, 2))
+        setRequestEditor(stringify(await grantPermission(), null, 2))
         break
       default:
         break
@@ -81,7 +81,7 @@ const Playground: FC<PlaygroundProps> = ({ title, configModal, errors, authorize
       const request = JSON.parse(requestEditor)
       const response = authorize && (await authorize(request))
       if (response) {
-        setResponseEditor(JSON.stringify(response, null, 2))
+        setResponseEditor(stringify(response, null, 2))
         const authResponseParsed = AuthorizationResponse.parse(response)
         setVaultAccessToken(authResponseParsed.evaluations[0]?.signature || '')
       }
@@ -99,7 +99,7 @@ const Playground: FC<PlaygroundProps> = ({ title, configModal, errors, authorize
       const request = JSON.parse(requestEditor)
       const response = evaluate && (await evaluate(request))
       if (response) {
-        setResponseEditor(JSON.stringify(response, null, 2))
+        setResponseEditor(stringify(response, null, 2))
         const evalResponseParsed = SendEvaluationResponse.parse(response)
         setVaultAccessToken(evalResponseParsed.accessToken?.value || '')
       }
@@ -121,7 +121,7 @@ const Playground: FC<PlaygroundProps> = ({ title, configModal, errors, authorize
       setIsProcessing(true)
       setResponseEditor(undefined)
       const response = await sign(signatureReq)
-      if (response) setResponseEditor(JSON.stringify(response, null, 2))
+      if (response) setResponseEditor(stringify(response, null, 2))
     } finally {
       setIsProcessing(false)
     }
@@ -135,7 +135,7 @@ const Playground: FC<PlaygroundProps> = ({ title, configModal, errors, authorize
       const response = await importAccount({ privateKey: hexSchema.parse(pk), accessToken: { value: accessToken } })
 
       if (response) {
-        setResponseEditor(JSON.stringify(response, null, 2))
+        setResponseEditor(stringify(response, null, 2))
       }
 
       return response
@@ -152,7 +152,7 @@ const Playground: FC<PlaygroundProps> = ({ title, configModal, errors, authorize
       const response = await importWallet({ seed, accessToken: { value: accessToken } })
 
       if (response) {
-        setResponseEditor(JSON.stringify(response, null, 2))
+        setResponseEditor(stringify(response, null, 2))
       }
 
       return response
@@ -169,7 +169,7 @@ const Playground: FC<PlaygroundProps> = ({ title, configModal, errors, authorize
       const response = await generateWallet({ keyId, accessToken: { value: accessToken } })
 
       if (response) {
-        setResponseEditor(JSON.stringify(response, null, 2))
+        setResponseEditor(stringify(response, null, 2))
       }
 
       return response
@@ -186,7 +186,7 @@ const Playground: FC<PlaygroundProps> = ({ title, configModal, errors, authorize
       const response = await deriveAccounts({ keyId, accessToken: { value: accessToken } })
 
       if (response) {
-        setResponseEditor(JSON.stringify(response, null, 2))
+        setResponseEditor(stringify(response, null, 2))
       }
 
       return response

--- a/apps/devtool/src/app/config/_components/vault/AddVaultClientModal.tsx
+++ b/apps/devtool/src/app/config/_components/vault/AddVaultClientModal.tsx
@@ -33,8 +33,7 @@ const AddVaultClientModal = () => {
   const [newClient, setNewClient] = useState<CreateVaultClientResponse>()
   const [form, setForm] = useState<VaultClientData>(initForm)
 
-  const isFormValid =
-    form.vaultUrl && form.vaultAdminApiKey && form.clientId && form.engineClientSigner && form.backupPublicKey
+  const isFormValid = form.vaultUrl && form.vaultAdminApiKey && form.clientId && form.engineClientSigner
 
   const closeDialog = () => {
     setIsOpen(false)
@@ -106,7 +105,7 @@ const AddVaultClientModal = () => {
             </div>
             <div className="flex flex-col gap-[8px] w-1/2">
               <NarInput
-                label="Backup Public Key"
+                label="Backup Public Key - RSA in PEM format (optional)"
                 value={form.backupPublicKey}
                 onChange={(backupPublicKey) => updateForm({ backupPublicKey })}
               />

--- a/apps/policy-engine/src/open-policy-agent/core/open-policy-agent.engine.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/open-policy-agent.engine.ts
@@ -114,7 +114,7 @@ export class OpenPolicyAgentEngine implements Engine<OpenPolicyAgentEngine> {
 
     const { results, transactionRequestIntent } = await this.opaEvaluate(evaluation, {
       principal: principalCredential,
-      approvals: approvalsCredential
+      approvals: [...approvalsCredential, principalCredential] // Include the Principal as an approver
     })
     const decision = this.decide(results)
 

--- a/packages/armory-sdk/src/lib/auth/client.ts
+++ b/packages/armory-sdk/src/lib/auth/client.ts
@@ -106,7 +106,8 @@ export class AuthClient {
     const request = SerializedAuthorizationRequest.pick({
       authentication: true,
       request: true,
-      metadata: true
+      metadata: true,
+      approvals: true
     }).parse({
       ...input,
       authentication


### PR DESCRIPTION
### Issue 1 - Devtool
Problem: Devtool uses `JSON.stringify` which can't serialize bigint. Devtool also makes vault `backupPublicKey` required, but it's a reasonable situation to have a vault where you want nothing to ever leave it.
Solution: use our stringify function & make the backupPublicKey optional in the form.

### Issue 2 - Engine Approvals
problem: Principal Authentication isn't included in Approvals, so even if `countPrincipalAsApprover` is set then they are not included.

solution: always put the principal authentication in the approvals list during evaluation