### PR TITLE
Making the Approvals array on AuthorizationRequest optional, it shouldnt be required

### DIFF
--- a/apps/armory/src/orchestration/persistence/repository/__test__/integration/authorization-request.repository.spec.ts
+++ b/apps/armory/src/orchestration/persistence/repository/__test__/integration/authorization-request.repository.spec.ts
@@ -282,9 +282,9 @@ describe(AuthorizationRequestRepository.name, () => {
 
       const actual = await repository.findById(signMessageRequest.id)
 
-      expect(authzRequestOne.approvals.length).toEqual(1)
-      expect(authzRequestTwo.approvals.length).toEqual(2)
-      expect(actual?.approvals.length).toEqual(2)
+      expect(authzRequestOne.approvals?.length).toEqual(1)
+      expect(authzRequestTwo.approvals?.length).toEqual(2)
+      expect(actual?.approvals?.length).toEqual(2)
     })
 
     it('appends errors', async () => {

--- a/packages/policy-engine-shared/src/lib/type/authorization-server.type.ts
+++ b/packages/policy-engine-shared/src/lib/type/authorization-server.type.ts
@@ -81,7 +81,7 @@ export const AuthorizationRequestMetadata = z.object({
 export type AuthorizationRequestMetadata = z.infer<typeof AuthorizationRequestMetadata>
 
 export const AuthorizationRequest = z.object({
-  approvals: z.array(JwtString),
+  approvals: z.array(JwtString).optional(),
   authentication: JwtString,
   clientId: z.string(),
   createdAt: z.coerce.date(),


### PR DESCRIPTION
the `approvals` field being required breaks the devtool for a `grantPermissions` request