### PR TITLE
config for deploying prod build of devtool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,3 +109,10 @@ docker/stack/build:
 		--tag armory/local:latest \
 		. --load
 
+
+# === Git ===
+git/tag/push:
+	git tag armory-$(TAG)
+	git tag policy-engine-$(TAG)
+	git tag vault-$(TAG)
+	git push origin armory-$(TAG) policy-engine-$(TAG) vault-$(TAG)

--- a/apps/devtool/project.json
+++ b/apps/devtool/project.json
@@ -9,7 +9,7 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/devtool"
+        "outputPath": "dist/apps/devtool"
       },
       "configurations": {
         "development": {},

--- a/packages/armory-sdk/src/index.ts
+++ b/packages/armory-sdk/src/index.ts
@@ -9,12 +9,9 @@ export * from './lib/vault'
 
 export { resourceId } from './lib/utils'
 
+export type { Alg, PrivateKey, PublicKey, RsaPublicKey, SigningAlg } from '@narval/signature'
+
 export {
-  Alg,
-  PrivateKey,
-  PublicKey,
-  RsaPublicKey,
-  SigningAlg,
   base64UrlToHex,
   buildSignerEip191,
   buildSignerForAlg,
@@ -28,7 +25,7 @@ export {
   signJwt
 } from '@narval/signature'
 
-export {
+export type {
   AccessToken,
   AccountEntity,
   AccountType,
@@ -40,7 +37,6 @@ export {
   Eip712TypedData,
   Entities,
   EntityType,
-  EntityUtil,
   Hex,
   JwtString,
   Policy,
@@ -50,7 +46,7 @@ export {
   TransactionRequest,
   UserEntity,
   UserRole,
-  ValueOperators,
-  getAddress,
-  toHex
+  ValueOperators
 } from '@narval/policy-engine-shared'
+
+export { EntityUtil, getAddress, toHex } from '@narval/policy-engine-shared'


### PR DESCRIPTION
In order to deploy devtool:
- Moved the build directory to match the other apps - `dist/apps/devtool`
- re-export sdk types as `export type` to support the `isolatedModules` flag

Other
- Added a makefile commit tag command, unrelated to vercel stuff.