### PR TITLE
Entity Manager empty state when DevTool is not configured

### DIFF
--- a/apps/devtool/src/app/_components/modals/AuthConfigModal.tsx
+++ b/apps/devtool/src/app/_components/modals/AuthConfigModal.tsx
@@ -2,14 +2,14 @@
 
 import { faGear } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { useEffect, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import NarButton from '../../_design-system/NarButton'
 import NarDialog from '../../_design-system/NarDialog'
 import NarInput from '../../_design-system/NarInput'
 import NarUrlInput from '../../_design-system/NarUrlInput'
 import useStore from '../../_hooks/useStore'
 
-interface ConfigForm {
+export interface ConfigForm {
   authUrl: string
   authClientId: string
   authClientSecret: string
@@ -25,7 +25,12 @@ const initForm: ConfigForm = {
   vaultClientId: ''
 }
 
-const AuthConfigModal = () => {
+
+interface AuthConfigModalProps {
+  onSave?: (form: ConfigForm) => void
+}
+
+const AuthConfigModal: FC<AuthConfigModalProps> = ({ onSave }) => {
   const {
     authUrl,
     authClientId,
@@ -36,7 +41,7 @@ const AuthConfigModal = () => {
     setAuthClientId,
     setAuthClientSecret,
     setVaultUrl,
-    setVaultClientId
+    setVaultClientId,
   } = useStore()
 
   const [isOpen, setIsOpen] = useState(false)
@@ -60,6 +65,10 @@ const AuthConfigModal = () => {
     setVaultUrl(form.vaultUrl)
     setVaultClientId(form.vaultClientId)
     closeDialog()
+
+    if (onSave) {
+      onSave(form)
+    }
   }
 
   useEffect(() => {

--- a/apps/devtool/src/app/config/_components/engine/EngineConfig.tsx
+++ b/apps/devtool/src/app/config/_components/engine/EngineConfig.tsx
@@ -16,7 +16,7 @@ const EngineConfig = () => {
       </div>
       <div className="flex flex-col gap-6">
         <NarUrlInput label="Engine URL" value={engineUrl} onValueChange={setEngineUrl} />
-        <NarInput label="Admin API Key" value={engineAdminApiKey} onChange={setEngineAdminApiKey} />
+        <NarInput label="Admin API Key" value={engineAdminApiKey} onChange={setEngineAdminApiKey} type="password" />
       </div>
     </div>
   )

--- a/apps/devtool/src/app/config/_components/vault/VaultConfig.tsx
+++ b/apps/devtool/src/app/config/_components/vault/VaultConfig.tsx
@@ -16,8 +16,7 @@ const VaultConfig = () => {
       </div>
       <div className="flex flex-col gap-6">
         <NarUrlInput label="Vault URL" value={vaultUrl} onValueChange={setVaultUrl} />
-        <NarInput label="Admin API Key" value={vaultAdminApiKey} onChange={setVaultAdminApiKey} />
-      </div>
+        <NarInput label="Admin API Key" value={vaultAdminApiKey} onChange={setVaultAdminApiKey} type="password" /> </div>
     </div>
   )
 }

--- a/apps/devtool/src/app/entity-manager/_components/EmptyState.tsx
+++ b/apps/devtool/src/app/entity-manager/_components/EmptyState.tsx
@@ -1,14 +1,15 @@
 import { IconDefinition, faBoxOpen } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 
 type EmptyStateProps = {
   title: string
   description: string
   icon?: IconDefinition
+  children?: ReactNode
 }
 
-const EmptyState: FC<EmptyStateProps> = ({ title, description, icon }) => (
+const EmptyState: FC<EmptyStateProps> = ({ title, description, icon, children }) => (
   <div className="flex flex-col items-center justify-center mb-6">
     <div className="flex flex-col items-center text-center gap-[14px] w-[479px]">
       <div className="flex flex-col items-center justify-center h-[80px] w-[80px] rounded-full bg-nv-neutrals-900">
@@ -16,6 +17,7 @@ const EmptyState: FC<EmptyStateProps> = ({ title, description, icon }) => (
       </div>
       <div className="text-nv-xl text-nv-white">{title}</div>
       <div className="text-nv-sm text-nv-neutrals-100">{description}</div>
+      {children}
     </div>
   </div>
 )


### PR DESCRIPTION
This PR adds an empty state when the DevTool is not configured on the local store to guide users.

![image](https://github.com/user-attachments/assets/91eb81c3-241f-4f37-908c-68db3ae050d4)
