### PR TITLE
Entity Manager Add User Modal Bugfix

### DIFF
--- a/apps/devtool/src/app/entity-manager/_components/UserForm.tsx
+++ b/apps/devtool/src/app/entity-manager/_components/UserForm.tsx
@@ -139,14 +139,12 @@ const UserForm: FC<UserFormProps> = (props) => {
 
   return (
     <div className="flex flex-col gap-6">
-      {user?.id && (
-        <NarInput
-          label="ID"
-          value={user?.id}
-          onChange={(id) => setUser((prev) => (prev ? { ...prev, id } : undefined))}
-          disabled={isEdit}
-        />
-      )}
+      <NarInput
+        label="ID"
+        value={user?.id || ''}
+        onChange={(id) => setUser((prev) => (prev ? { ...prev, id } : undefined))}
+        disabled={isEdit}
+      />
 
       <NarDropdownMenu
         label="Role"


### PR DESCRIPTION
- Add User modal didn't displayed 'id' field when the input string was empty

Solution:
- Always render the 'id' field on the modal
- Start with an empty string if current state is undefined for user.id