### PR TITLE
Remove authn request error context

### DIFF
--- a/apps/armory/src/orchestration/persistence/decode/authorization-request.decode.ts
+++ b/apps/armory/src/orchestration/persistence/decode/authorization-request.decode.ts
@@ -1,4 +1,3 @@
-import { Json } from '@narval/nestjs-shared'
 import { Action, AuthorizationRequest, AuthorizationRequestError, Evaluation } from '@narval/policy-engine-shared'
 import {
   AuthorizationRequestError as AuthorizationRequestErrorModel,
@@ -22,11 +21,10 @@ const buildEvaluation = ({ id, decision, signature, createdAt }: EvaluationLogMo
   createdAt
 })
 
-const buildError = ({ id, message, name, context }: AuthorizationRequestErrorModel): AuthorizationRequestError => ({
+const buildError = ({ id, message, name }: AuthorizationRequestErrorModel): AuthorizationRequestError => ({
   id,
   message,
-  name,
-  context: Json.parse(context)
+  name
 })
 
 const buildSharedAttributes = (model: Model): Omit<AuthorizationRequest, 'action' | 'request'> => {

--- a/apps/armory/src/orchestration/persistence/repository/__test__/integration/authorization-request.repository.spec.ts
+++ b/apps/armory/src/orchestration/persistence/repository/__test__/integration/authorization-request.repository.spec.ts
@@ -165,13 +165,7 @@ describe(AuthorizationRequestRepository.name, () => {
       const error: AuthorizationRequestError = {
         id: 'test-error-id',
         name: 'ErrorName',
-        message: 'Something went wrong',
-        context: {
-          moreInformation: true,
-          someText: 'foo',
-          aNumber: 123,
-          nullable: null
-        }
+        message: 'Something went wrong'
       }
 
       await repository.create({

--- a/apps/armory/src/orchestration/persistence/repository/authorization-request.repository.ts
+++ b/apps/armory/src/orchestration/persistence/repository/authorization-request.repository.ts
@@ -6,7 +6,6 @@ import {
   Evaluation
 } from '@narval/policy-engine-shared'
 import { Injectable } from '@nestjs/common'
-import { Prisma } from '@prisma/client/armory'
 import { v4 as uuid } from 'uuid'
 import { PrismaService } from '../../../shared/module/persistence/service/prisma.service'
 import { decodeAuthorizationRequest } from '../decode/authorization-request.decode'
@@ -79,8 +78,7 @@ export class AuthorizationRequestRepository {
         id: error.id,
         clientId,
         name: error.name,
-        message: error.message,
-        context: error.context as Prisma.InputJsonValue
+        message: error.message
       }))
     }
 

--- a/apps/armory/src/shared/module/persistence/schema/migrations/20240731091321_drop_authz_request_error_context/migration.sql
+++ b/apps/armory/src/shared/module/persistence/schema/migrations/20240731091321_drop_authz_request_error_context/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `context` on the `authorization_request_error` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "authorization_request_error" DROP COLUMN "context";

--- a/apps/armory/src/shared/module/persistence/schema/schema.prisma
+++ b/apps/armory/src/shared/module/persistence/schema/schema.prisma
@@ -99,7 +99,6 @@ model AuthorizationRequestError {
   requestId String @map("request_id")
   name      String
   message   String
-  context   Json?
 
   request AuthorizationRequest @relation(fields: [requestId], references: [id])
 


### PR DESCRIPTION
This PR removes the authn request error context from the domain and database model. The context may contain sensitive information that's properly redacted on logs but never sanitized before writing to the database.

The context with redacted sensitive information will be available in the server logs.

