### PR TITLE
Prefix DevTool profile environment variable with NEXT_PUBLIC_

### DIFF
--- a/apps/devtool/src/app/_lib/config.ts
+++ b/apps/devtool/src/app/_lib/config.ts
@@ -16,5 +16,5 @@ export const env = z
     profile: z.enum(['devtool', 'manager']).default('devtool')
   })
   .parse({
-    profile: process.env.APP_PROFILE
+    profile: process.env.NEXT_PUBLIC_APP_PROFILE
   })


### PR DESCRIPTION
Non-`NEXT_PUBLIC_` prefixed environment variables are only available in the Node.js runtime which explains why it worked on my local build but not in production.

See https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser