### PR TITLE
Updating swagger for gnap header, removing unused/outdated signing methods in devtool/sdk

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,4 +9,5 @@ deploy/charts/*
 
 # Generated code
 packages/armory-sdk/src/http/client
+packages/armory-sdk/src/lib/http/client
 packages/policy-engine-shared/src/tsmsdkv2

--- a/apps/devtool/src/app/_hooks/useAccountSignature.tsx
+++ b/apps/devtool/src/app/_hooks/useAccountSignature.tsx
@@ -1,15 +1,4 @@
-import {
-  Curves,
-  JwsdHeader,
-  KeyTypes,
-  Payload,
-  PublicKey,
-  SigningAlg,
-  hash,
-  hexToBase64Url,
-  signJwsd,
-  signJwt
-} from '@narval/signature'
+import { Curves, KeyTypes, PublicKey, SigningAlg, hexToBase64Url } from '@narval/signature'
 import { signMessage } from '@wagmi/core'
 import { useEffect, useState } from 'react'
 import { useAccount } from 'wagmi'
@@ -37,37 +26,7 @@ const useAccountSignature = () => {
     return hexToBase64Url(signature)
   }
 
-  const signAccountJwt = async (payload: Payload) => {
-    if (!jwk) return ''
-
-    const signature = await signJwt(payload, jwk, { alg: SigningAlg.EIP191 }, signer)
-
-    return signature
-  }
-
-  const signAccountJwsd = async (payload: any, opts: { accessToken: string; uri: string }) => {
-    if (!jwk) return ''
-
-    const jwsdHeader: JwsdHeader = {
-      alg: SigningAlg.EIP191,
-      kid: jwk.kid,
-      typ: 'gnap-binding-jwsd',
-      htm: 'POST',
-      uri: opts.uri,
-      created: new Date().getTime(),
-      ath: hexToBase64Url(hash(opts.accessToken))
-    }
-
-    const signature = await signJwsd(payload, jwsdHeader, signer).then((jws) => {
-      const parts = jws.split('.')
-      parts[1] = ''
-      return parts.join('.')
-    })
-
-    return signature
-  }
-
-  return { jwk, signer, signAccountJwt, signAccountJwsd }
+  return { jwk, signer }
 }
 
 export default useAccountSignature

--- a/packages/armory-sdk/src/lib/http/client/auth/api.ts
+++ b/packages/armory-sdk/src/lib/http/client/auth/api.ts
@@ -694,7 +694,7 @@ export interface AuthorizationResponseDto {
      * @type {Array<string>}
      * @memberof AuthorizationResponseDto
      */
-    'approvals': Array<string>;
+    'approvals'?: Array<string>;
     /**
      * 
      * @type {string}

--- a/packages/armory-sdk/src/lib/http/client/vault/api.ts
+++ b/packages/armory-sdk/src/lib/http/client/vault/api.ts
@@ -1375,8 +1375,6 @@ export const AccountApiAxiosParamCreator = function (configuration?: Configurati
             const localVarQueryParameter = {} as any;
 
             // authentication GNAP required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             if (xClientId != null) {
                 localVarHeaderParameter['x-client-id'] = String(xClientId);
@@ -1429,8 +1427,6 @@ export const AccountApiAxiosParamCreator = function (configuration?: Configurati
             const localVarQueryParameter = {} as any;
 
             // authentication GNAP required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             if (xClientId != null) {
                 localVarHeaderParameter['x-client-id'] = String(xClientId);
@@ -1480,8 +1476,6 @@ export const AccountApiAxiosParamCreator = function (configuration?: Configurati
             const localVarQueryParameter = {} as any;
 
             // authentication GNAP required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             if (xClientId != null) {
                 localVarHeaderParameter['x-client-id'] = String(xClientId);
@@ -1907,8 +1901,6 @@ export const EncryptionKeyApiAxiosParamCreator = function (configuration?: Confi
             const localVarQueryParameter = {} as any;
 
             // authentication GNAP required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             if (xClientId != null) {
                 localVarHeaderParameter['x-client-id'] = String(xClientId);
@@ -2035,8 +2027,6 @@ export const SignApiAxiosParamCreator = function (configuration?: Configuration)
             const localVarQueryParameter = {} as any;
 
             // authentication GNAP required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             if (xClientId != null) {
                 localVarHeaderParameter['x-client-id'] = String(xClientId);
@@ -2169,8 +2159,6 @@ export const WalletApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarQueryParameter = {} as any;
 
             // authentication GNAP required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             if (xClientId != null) {
                 localVarHeaderParameter['x-client-id'] = String(xClientId);
@@ -2223,8 +2211,6 @@ export const WalletApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarQueryParameter = {} as any;
 
             // authentication GNAP required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             if (xClientId != null) {
                 localVarHeaderParameter['x-client-id'] = String(xClientId);
@@ -2274,8 +2260,6 @@ export const WalletApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarQueryParameter = {} as any;
 
             // authentication GNAP required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             if (xClientId != null) {
                 localVarHeaderParameter['x-client-id'] = String(xClientId);

--- a/packages/armory-sdk/src/lib/utils.ts
+++ b/packages/armory-sdk/src/lib/utils.ts
@@ -1,10 +1,10 @@
 import { Decision, EvaluationResponse, JwtString, Request, isAddress } from '@narval/policy-engine-shared'
-import { JwsdHeader, Payload, buildSignerForAlg, hash, hexToBase64Url, signJwsd } from '@narval/signature'
+import { JwsdHeader, Payload, hash, hexToBase64Url } from '@narval/signature'
 import { v4 } from 'uuid'
 import { Address, Chain, Hex } from 'viem'
 import { mainnet, optimism, polygon } from 'viem/chains'
 import { DETACHED_JWS, HEADER_CLIENT_ID, HEADER_CLIENT_SECRET } from './constants'
-import { ArmoryClientConfig, JwsdHeaderArgs, SignAccountJwsdArgs } from './domain'
+import { ArmoryClientConfig, JwsdHeaderArgs } from './domain'
 import { ArmorySdkException, ForbiddenException, NotImplementedException } from './exceptions'
 import { BasicHeaders, GnapHeaders } from './schema'
 import { SendEvaluationResponse } from './types/policy-engine'
@@ -31,26 +31,6 @@ export const buildJwsdHeader = (args: JwsdHeaderArgs): JwsdHeader => {
     created: new Date().getTime(),
     ath: hexToBase64Url(hash(accessToken.value))
   }
-}
-
-export const signAccountJwsd = async (args: SignAccountJwsdArgs) => {
-  const { payload, accessToken, jwk, uri, htm } = args
-
-  let signer = args.signer
-  let alg = args.alg
-
-  if (!signer) {
-    signer = await buildSignerForAlg(jwk)
-    alg = jwk.alg
-  }
-
-  const jwsdHeader = buildJwsdHeader({ accessToken, jwk, alg, uri, htm })
-
-  return signJwsd(payload, jwsdHeader, signer).then((jws) => {
-    const parts = jws.split('.')
-    parts[1] = ''
-    return parts.join('.')
-  })
 }
 
 export const resourceId = (walletIdOrAddress: Address | string): string => {

--- a/packages/nestjs-shared/src/lib/util/with-swagger.util.ts
+++ b/packages/nestjs-shared/src/lib/util/with-swagger.util.ts
@@ -13,12 +13,10 @@ export const gnapSecurity = (): Security => ({
   name: 'GNAP',
   type: 'http',
   in: 'header',
-  // TODO: (@wcalderipe, 11/06/24) Swagger points `gnap` scheme as invalid.
   // A scheme is what sits in front of the token `Authorization: <scheme>
   // <token>`.
   // See https://swagger.io/docs/specification/authentication/
-  scheme: 'bearer',
-  bearerFormat: 'GNAP'
+  scheme: 'GNAP'
 })
 
 export const adminApiKeySecurity = (header: string): Security => ({


### PR DESCRIPTION
Deleted some JWT/JWS building/signing methods. They are not used anywhere. Appears to be leftover before this was all part of the SDK.

Also updated the swagger to use GNAP http authentication scheme rather than Bearer (because it's not a bearer token)