### PR TITLE
Fix logs not showing up on all servers

### DIFF
--- a/packages/nestjs-shared/src/lib/module/logger/__test__/unit/logger.util.spec.ts
+++ b/packages/nestjs-shared/src/lib/module/logger/__test__/unit/logger.util.spec.ts
@@ -43,107 +43,69 @@ describe('redact', () => {
 
   it('does not mutate the given object', () => {
     const obj = {
-      "approvals": [],
-      "authentication": "eyJhbGciOiJFSVAxOTEiLCJraWQiOiIweDc2MEE2MkYzMjIyOUM3Y2EyN0JFNDZFOTUwZTQzOEFiZTE3MjZkYzEiLCJ0eXAiOiJKV1QifQ.eyJpYXQiOjE3MjIzNTA4MDE2ODIsImlzcyI6IjgxMWViYWYxLTczMjktNDg1ZC04ZGI2LThhY2MwZWFkNGZiNyIsInJlcXVlc3RIYXNoIjoiMHhkZDgyZjgzMGQ0YTZmYzczMDMxMDc0NmJiOGI2NTM5ODhkNTkwNGFiZTU0YTFiZDc5YTllYTc3NDg4ZmQ4YzIzIiwic3ViIjoiMHg3NjBBNjJGMzIyMjlDN2NhMjdCRTQ2RTk1MGU0MzhBYmUxNzI2ZGMxIn0.xIn6xt-zKF1tA77t-qpPPoPVDN3kkDaIukfVUZ_d6xJ8mJRmzpZvZ83av607GERdtXoeLjVy1bRa-tEgRr38RRw",
-      "clientId": "811ebaf1-7329-485d-8db6-8acc0ead4fb7",
-      "createdAt": "2024-07-30T14:46:43.384Z",
-      "errors": [
+      foo: [
         {
-          "context": {
-            "data": {
-              "feeds": [
-                {
-                  "sig": "eyJhbGciOiJFSVAxOTEiLCJraWQiOiIweDBjNjIwZjRiYzhlOTMxMTBiZDljZDc5ZTVkNjM3YTI0MGQ1NWUwZjI3MzNmZDdlOTViNzM0N2QzYjA2MjMxZmMiLCJ0eXAiOiJKV1QifQ.eyJkYXRhIjoiMHg0NDEzNmZhMzU1YjM2NzhhMTE0NmFkMTZmN2U4NjQ5ZTk0ZmI0ZmMyMWZlNzdlODMxMGMwNjBmNjFjYWFmZjhhIiwiaWF0IjoxNzIyMzUwODA4LCJpc3MiOiJodHRwczovL2FybW9yeS5uYXJ2YWwueHl6Iiwic3ViIjoiMHg2OTY2MzEzNDAwMTZGY2FFMmJCYmEyREQ3QmYxZjFBMkY4ZTJBNTRmIn0.fMvqRJhm_sH6QuYalz1J4iFT2D0IT72lC84eC6k3xhMn48uPW1P2bncxhO_ofigDvutTGlV9OYtFqTuAc8j7-xs",
-                  "data": {},
-                  "source": "armory/price-feed"
-                },
-                {
-                  "sig": "eyJhbGciOiJFSVAxOTEiLCJraWQiOiIweDY2YTY3YWI1ODI2OWY0NGFhYmE2NDUxNzZmNGI5M2Y1ZTY3MTU2N2I0NTQ0MjkwZTE5OGU5ODYxYzM0OTNkMmQiLCJ0eXAiOiJKV1QifQ.eyJkYXRhIjoiMHg0ZjUzY2RhMThjMmJhYTBjMDM1NGJiNWY5YTNlY2JlNWVkMTJhYjRkOGUxMWJhODczYzJmMTExNjEyMDJiOTQ1IiwiaWF0IjoxNzIyMzUwODA4LCJpc3MiOiJodHRwczovL2FybW9yeS5uYXJ2YWwueHl6Iiwic3ViIjoiMHhkOWYzYjNhMDY3ZmU0NmI2M0U0YjBkZUZlQjJBMGI3YWU2N2E4MjIxIn0.sAYS88tXduXHzSiNbiaKwUi0GNkkHsCFa5eCiHgCRYRdy28YGd0Ax2Z_7vs7e8zYRKYVLEEBwa9N15tj-QM1xhw",
-                  "data": [
-                    {
-                      "token": "[THIS_SHOULD_NOT_BE_REDACTED]"
-                    },
-                    {
-                      "token": "[THIS_SHOULD_NOT_BE_REDACTED]"
-                    }
-                  ],
-                  "source": "armory/historical-transfer-feed"
-                }
-              ],
-              "request": {
-                "nonce": "cd0cf10c-6139-4779-b754-66689b016a0e",
-                "action": "grantPermission",
-                "resourceId": "vault",
-                "permissions": [
-                  "wallet:create",
-                  "wallet:read",
-                  "wallet:import"
-                ],
-                "token": "[THIS_SHOULD_NOT_BE_REDACTED]"
-              },
-              "metadata": {
-                "issuer": "811ebaf1-7329-485d-8db6-8acc0ead4fb7.armory.narval.xyz",
-                "issuedAt": 1722350803,
-                "expiresIn": 600
-              },
-              "approvals": [],
-              "sessionId": "7dd1caff-40df-4a3c-8575-a430e4053da1",
-              "authentication": "eyJhbGciOiJFSVAxOTEiLCJraWQiOiIweDc2MEE2MkYzMjIyOUM3Y2EyN0JFNDZFOTUwZTQzOEFiZTE3MjZkYzEiLCJ0eXAiOiJKV1QifQ.eyJpYXQiOjE3MjIzNTA4MDE2ODIsImlzcyI6IjgxMWViYWYxLTczMjktNDg1ZC04ZGI2LThhY2MwZWFkNGZiNyIsInJlcXVlc3RIYXNoIjoiMHhkZDgyZjgzMGQ0YTZmYzczMDMxMDc0NmJiOGI2NTM5ODhkNTkwNGFiZTU0YTFiZDc5YTllYTc3NDg4ZmQ4YzIzIiwic3ViIjoiMHg3NjBBNjJGMzIyMjlDN2NhMjdCRTQ2RTk1MGU0MzhBYmUxNzI2ZGMxIn0.xIn6xt-zKF1tA77t-qpPPoPVDN3kkDaIukfVUZ_d6xJ8mJRmzpZvZ83av607GERdtXoeLjVy1bRa-tEgRr38RRw"
-            },
-            "host": "http://policy-engine-node-2",
-            "clientId": "811ebaf1-7329-485d-8db6-8acc0ead4fb7",
-            "clientSecret": "[THIS_SHOULD_NOT_BE_REDACTED]"
-          },
-          "id": "acdff6bf-4dcd-4541-9db1-786f53cb3e9c",
-          "message": "Evaluation request failed",
-          "name": "PolicyEngineClientException"
+          secret: 'DO NOT MUTATE'
+        },
+        {
+          password: 'DO NOT MUTATE'
         }
       ],
-      "evaluations": [],
-      "id": "9a3920d8-f9ef-4400-bced-e9cf2a2810f0",
-      "idempotencyKey": null,
-      "metadata": {
-        "expiresIn": 600
-      },
-      "request": {
-        "action": "grantPermission",
-        "nonce": "cd0cf10c-6139-4779-b754-66689b016a0e",
-        "resourceId": "vault",
-        "permissions": [
-          "wallet:create",
-          "wallet:read",
-          "wallet:import"
+      bar: {
+        baz: [
+          {
+            secret: 'DO NOT MUTATE'
+          }
         ]
-      },
-      "status": "FAILED",
-      "updatedAt": "2024-07-30T14:46:48.713Z"
+      }
     }
 
     redact(obj)
 
-    expect(obj.errors[0].context.data.request.token).toEqual('[THIS_SHOULD_NOT_BE_REDACTED]')
-    expect(obj.errors[0].context.clientSecret).toEqual('[THIS_SHOULD_NOT_BE_REDACTED]')
-    expect((obj.errors[0].context.data.feeds[1].data as {token: string}[])[0].token).toEqual('[THIS_SHOULD_NOT_BE_REDACTED]')
-    expect((obj.errors[0].context.data.feeds[1].data as {token: string}[])[1].token).toEqual('[THIS_SHOULD_NOT_BE_REDACTED]')
+    expect(obj.foo[0].secret).toEqual('DO NOT MUTATE')
+    expect(obj.foo[1].password).toEqual('DO NOT MUTATE')
+    expect(obj.bar.baz[0].secret).toEqual('DO NOT MUTATE')
   })
-  it('does not mutate the given object with a class extending Error', () => {
-    class TestClass extends Error {
-      constructor(public config: { host: string; clientId: string; clientSecret: string }) {
+
+  it('does not mutate the node when it extends Error', () => {
+    class TestError extends Error {
+      constructor(public config: { secret: string }) {
         super('TestClass')
       }
     }
 
     const obj = {
-      foo: 'DO NOT REDACT THIS',
-      bar: new TestClass({
-        host: 'http://policy-engine-node-2',
-        clientId: '811ebaf1-7329-485d-8db6-8acc0ead4fb7',
-        clientSecret: '[THIS_SHOULD_NOT_BE_REDACTED]'
+      foo: new TestError({
+        secret: 'DO NOT MUTATE'
       })
-    };
+    }
 
-    redact(obj);
+    redact(obj)
 
-    expect(obj.bar.config.clientSecret).toEqual('[THIS_SHOULD_NOT_BE_REDACTED]');
+    expect(obj.foo.config.secret).toEqual('DO NOT MUTATE')
+  })
+
+  it('does not mutate the node when it is a class', () => {
+    class TestClass {
+      private secret: string
+      public password: string
+
+      constructor(input: { secret: string; password: string }) {
+        this.secret = input.secret
+        this.password = input.password
+      }
+    }
+
+    const obj = {
+      foo: new TestClass({
+        secret: 'DO NOT MUTATE',
+        password: 'DO NOT MUTATE'
+      })
+    }
+
+    redact(obj)
+
+    expect(obj.foo['secret']).toEqual('DO NOT MUTATE')
+    expect(obj.foo.password).toEqual('DO NOT MUTATE')
   })
 })

--- a/packages/nestjs-shared/src/lib/module/logger/logger.util.ts
+++ b/packages/nestjs-shared/src/lib/module/logger/logger.util.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common'
 import { cloneDeep } from 'lodash'
-import traverse from 'traverse'
+import traverse, { clone } from 'traverse'
 import { REDACT_KEYS, REDACT_REPLACE } from './logger.constant'
 import { LoggerService } from './service/logger.service'
 
@@ -15,7 +15,13 @@ const isSensitiveKey = (key?: string): boolean => {
 export const redact = <T>(input: T): T => {
   const copy = cloneDeep(input)
 
-  return traverse(copy).map(function redactor() {
+  return traverse(copy).forEach(function redactor() {
+    // Prevents a mutation in the original input when the value is a class
+    // extending Error.
+    if (this.node instanceof Error) {
+      this.update(clone(this.node))
+    }
+
     if (isSensitiveKey(this.key)) {
       this.update(REDACT_REPLACE)
     }


### PR DESCRIPTION
For some mysterious reason, a traversed object using `.map` is not formatted by Winston, resulting in the logs being swallowed. For further context, we moved to `.map` because it's supposed to clone the node before changing it to fix a mutation issue on the API responses (see #469).

This PR goes back to `.forEach` but ensures nodes that are classes extending from Error are cloned. It also cleans up the noise in the test file by reducing the input samples to a bare minimum.