### PR TITLE
Add wallet generation and accounts derivation in the entity manager

### DIFF
--- a/apps/devtool/src/app/_hooks/useVaultApi.tsx
+++ b/apps/devtool/src/app/_hooks/useVaultApi.tsx
@@ -188,9 +188,9 @@ const useVaultApi = () => {
       setErrors(undefined)
       setIsProcessing(true)
 
-      const { accessToken } = request
+      const { accessToken, ...data } = request
 
-      return vaultClient.generateWallet({ accessToken })
+      return vaultClient.generateWallet({ accessToken, data })
     } catch (error) {
       setErrors(extractErrorMessage(error))
       throw error

--- a/apps/devtool/src/app/entity-manager/_components/DeriveAccountDialog.tsx
+++ b/apps/devtool/src/app/entity-manager/_components/DeriveAccountDialog.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { Permission } from '@narval/armory-sdk'
+import { AccountType, Action, Entities, EntityUtil, hexSchema } from '@narval/policy-engine-shared'
+import { parseInt } from 'lodash'
+import { Dispatch, FC, SetStateAction, useState } from 'react'
+import { v4 as uuid } from 'uuid'
+import NarButton from '../../_design-system/NarButton'
+import NarDialog from '../../_design-system/NarDialog'
+import NarInput from '../../_design-system/NarInput'
+import useAuthServerApi from '../../_hooks/useAuthServerApi'
+import useVaultApi from '../../_hooks/useVaultApi'
+
+interface DeriveAccountsDialogProps {
+  setEntities: Dispatch<SetStateAction<Entities>>
+}
+
+const DeriveAccountsDialog: FC<DeriveAccountsDialogProps> = (props) => {
+  const { deriveAccounts } = useVaultApi()
+  const { requestAccessToken } = useAuthServerApi()
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [keyId, setKeyId] = useState('')
+  const [count, setCount] = useState('')
+
+  const handleClose = () => {
+    setIsDialogOpen(false)
+    setKeyId('')
+    setCount('')
+  }
+
+  const handleSave = async () => {
+    try {
+      setIsProcessing(true)
+
+      const accessToken = await requestAccessToken({
+        action: Action.GRANT_PERMISSION,
+        resourceId: 'vault',
+        nonce: uuid(),
+        permissions: [Permission.WALLET_CREATE]
+      })
+
+      if (accessToken) {
+        const response = await deriveAccounts({
+          accessToken,
+          keyId,
+          count: count ? parseInt(count) : 1
+        })
+
+        if (response) {
+          props.setEntities((prev) =>
+            EntityUtil.addAccounts(
+              prev,
+              response.accounts.map((account) => ({
+                id: account.id,
+                address: hexSchema.parse(account.address),
+                accountType: AccountType.EOA
+              }))
+            )
+          )
+
+          setIsDialogOpen(false)
+        }
+      }
+    } finally {
+      setIsProcessing(false)
+    }
+  }
+
+  return (
+    <NarDialog
+      triggerButton={<NarButton label="Derive" />}
+      title="Derive Accounts"
+      primaryButtonLabel={'Derive'}
+      isOpen={isDialogOpen}
+      onOpenChange={(val) => (val ? setIsDialogOpen(val) : handleClose())}
+      onDismiss={handleClose}
+      onSave={handleSave}
+      isSaving={isProcessing}
+      isSaveDisabled={isProcessing}
+    >
+      <div className="w-[750px] px-12 py-4">
+        <div className="flex flex-col gap-[8px]">
+          <NarInput label="Wallet Key ID" value={keyId} onChange={setKeyId} />
+          <NarInput label="Count (optional)" value={count} onChange={setCount} />
+        </div>
+      </div>
+    </NarDialog>
+  )
+}
+
+export default DeriveAccountsDialog

--- a/apps/devtool/src/app/entity-manager/_components/EntityManager.tsx
+++ b/apps/devtool/src/app/entity-manager/_components/EntityManager.tsx
@@ -6,7 +6,6 @@ import {
   faDatabase,
   faDotCircle,
   faIdBadge,
-  faPlus,
   faRotateRight,
   faShield,
   faSpinner,
@@ -39,7 +38,9 @@ import AccountForm from './AccountForm'
 import AssignAccountForm from './AssignAccountForm'
 import CredentialCard from './CredentialCard'
 import CredentialForm from './CredentialForm'
+import DeriveAccountsDialog from './DeriveAccountDialog'
 import EmptyState from './EmptyState'
+import GenerateWalletDialog from './GenerateWalletDialog'
 import ImportKeyDialog from './ImportKeyDialog'
 import Info from './Info'
 import Message from './Message'
@@ -79,7 +80,7 @@ export default function EntityManager() {
       isSigningPolicy,
       isSigningAndPushingEntity,
       isSigningAndPushingPolicy,
-      policyFetchError,
+      policyFetchError
     },
     getEntityStore,
     getPolicyStore,
@@ -197,6 +198,8 @@ export default function EntityManager() {
                   signAndPushEntity(entities)
                 }}
               />
+
+              <GenerateWalletDialog setEntities={setEntities} />
             </>
           )}
 
@@ -249,10 +252,12 @@ export default function EntityManager() {
                   onSave={() => setImportKeyDialogOpen(false)}
                 />
 
+                <DeriveAccountsDialog setEntities={setEntities} />
+
                 <NarDialog
-                  triggerButton={<NarButton label="Add" leftIcon={<FontAwesomeIcon icon={faPlus} />} />}
-                  title="Add Account"
-                  primaryButtonLabel={'Add'}
+                  triggerButton={<NarButton label="Track" />}
+                  title="Track Account"
+                  primaryButtonLabel={'Track'}
                   isOpen={isAccountDialogOpen}
                   onOpenChange={setAccountDialogOpen}
                   onDismiss={() => {
@@ -301,7 +306,7 @@ export default function EntityManager() {
               </div>
 
               <NarDialog
-                triggerButton={<NarButton label="Add" leftIcon={<FontAwesomeIcon icon={faPlus} />} />}
+                triggerButton={<NarButton label="Add" />}
                 title="Add User"
                 primaryButtonLabel={'Add'}
                 isOpen={isAddUserDialogOpen}

--- a/apps/devtool/src/app/entity-manager/_components/GenerateWalletDialog.tsx
+++ b/apps/devtool/src/app/entity-manager/_components/GenerateWalletDialog.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { faCheckCircle, faWallet } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { GenerateKeyResponse, Permission } from '@narval/armory-sdk'
+import { AccountType, Action, Entities, EntityUtil, hexSchema } from '@narval/policy-engine-shared'
+import { Dispatch, FC, SetStateAction, useMemo, useState } from 'react'
+import { v4 as uuid } from 'uuid'
+import ValueWithCopy from '../../_components/ValueWithCopy'
+import NarButton from '../../_design-system/NarButton'
+import NarDialog from '../../_design-system/NarDialog'
+import NarInput from '../../_design-system/NarInput'
+import useAuthServerApi from '../../_hooks/useAuthServerApi'
+import useVaultApi from '../../_hooks/useVaultApi'
+
+enum Steps {
+  FORM,
+  SUCCESS
+}
+
+interface GenerateWalletDialogProps {
+  isOpen?: boolean
+  setEntities: Dispatch<SetStateAction<Entities>>
+}
+
+const GenerateWalletDialog: FC<GenerateWalletDialogProps> = (props) => {
+  const { generateWallet } = useVaultApi()
+  const { requestAccessToken } = useAuthServerApi()
+
+  const [currentStep, setCurrentStep] = useState<Steps>(Steps.FORM)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [keyId, setKeyId] = useState('')
+  const [generatedWallet, setGeneratedWallet] = useState<GenerateKeyResponse>()
+
+  const btnLabel = useMemo(() => {
+    const labels: Record<number, string> = {
+      [Steps.FORM]: 'Generate',
+      [Steps.SUCCESS]: 'Confirm'
+    }
+
+    return labels[currentStep] || 'Processing...'
+  }, [currentStep])
+
+  const handleClose = () => {
+    setIsDialogOpen(false)
+    setGeneratedWallet(undefined)
+    setKeyId('')
+    setCurrentStep(Steps.FORM)
+  }
+
+  const handleSave = async () => {
+    try {
+      setIsProcessing(true)
+
+      const accessToken = await requestAccessToken({
+        action: Action.GRANT_PERMISSION,
+        resourceId: 'vault',
+        nonce: uuid(),
+        permissions: [Permission.WALLET_CREATE]
+      })
+
+      if (accessToken) {
+        const wallet = await generateWallet({
+          accessToken,
+          keyId
+        })
+
+        if (wallet) {
+          setGeneratedWallet(wallet)
+
+          props.setEntities((prev) =>
+            EntityUtil.addAccount(prev, {
+              id: wallet.account.id,
+              address: hexSchema.parse(wallet.account.address),
+              accountType: AccountType.EOA
+            })
+          )
+
+          setCurrentStep(Steps.SUCCESS)
+        }
+      }
+    } finally {
+      setIsProcessing(false)
+    }
+  }
+
+  return (
+    <NarDialog
+      triggerButton={
+        <NarButton label="Generate Wallet" variant="secondary" leftIcon={<FontAwesomeIcon icon={faWallet} />} />
+      }
+      title="Generate Wallet"
+      primaryButtonLabel={btnLabel}
+      isOpen={isDialogOpen}
+      onOpenChange={(val) => (val ? setIsDialogOpen(val) : handleClose())}
+      onDismiss={handleClose}
+      onSave={handleSave}
+      isSaving={isProcessing}
+      isConfirm={currentStep === Steps.SUCCESS}
+      isSaveDisabled={isProcessing}
+    >
+      <div className="w-[750px] px-12 py-4">
+        {currentStep === Steps.FORM && (
+          <div className="flex flex-col gap-[8px]">
+            <div className="flex items-end gap-[8px]">
+              <NarInput label="Key ID (optional)" value={keyId} onChange={setKeyId} />
+            </div>
+          </div>
+        )}
+
+        {currentStep === Steps.SUCCESS && (
+          <div className="flex flex-col gap-[16px]">
+            <div className="flex items-center gap-[8px]">
+              <FontAwesomeIcon className="text-nv-green-500" icon={faCheckCircle} />
+              <div className="text-nv-lg">Wallet generate successfully!</div>
+            </div>
+            {generatedWallet && (
+              <div className="flex flex-col gap-[8px]">
+                <ValueWithCopy layout="horizontal" label="Key ID" value={generatedWallet.keyId} />
+                <ValueWithCopy layout="horizontal" label="Account ID" value={generatedWallet.account.id} />
+                <ValueWithCopy layout="horizontal" label="Account Address" value={generatedWallet.account.address} />
+                <ValueWithCopy
+                  layout="horizontal"
+                  label="Derivation Path"
+                  value={generatedWallet.account.derivationPath}
+                />
+                <ValueWithCopy layout="horizontal" label="Backup" value={generatedWallet.backup} />
+              </div>
+            )}
+            <p className="text-nv-lg">Save the wallet Key ID somewhere. You'll need it to derive accounts later.</p>
+          </div>
+        )}
+      </div>
+    </NarDialog>
+  )
+}
+
+export default GenerateWalletDialog

--- a/apps/devtool/src/app/entity-manager/_components/ImportKeyDialog.tsx
+++ b/apps/devtool/src/app/entity-manager/_components/ImportKeyDialog.tsx
@@ -1,5 +1,4 @@
-import { faUpload, faXmarkCircle } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faXmarkCircle } from '@fortawesome/free-solid-svg-icons'
 import { Permission } from '@narval/armory-sdk'
 import { AccountEntity, AccountType, Action, Entities, getAddress } from '@narval/policy-engine-shared'
 import { Hex } from '@narval/signature'
@@ -46,7 +45,7 @@ export default function ImportKeyDialog(props: ImportKeyDialogProp) {
         action: Action.GRANT_PERMISSION,
         resourceId: 'vault',
         nonce: uuid(),
-        permissions: [Permission.WALLET_IMPORT, Permission.WALLET_CREATE, Permission.WALLET_READ]
+        permissions: [Permission.WALLET_IMPORT, Permission.WALLET_CREATE]
       })
 
       if (!accessToken) {
@@ -93,8 +92,8 @@ export default function ImportKeyDialog(props: ImportKeyDialogProp) {
 
   return (
     <NarDialog
-      triggerButton={<NarButton label={'Import'} leftIcon={<FontAwesomeIcon icon={faUpload} />} />}
-      title={'Import'}
+      triggerButton={<NarButton label={'Import'} />}
+      title={'Import Account'}
       primaryButtonLabel={'Import'}
       isOpen={Boolean(props.isOpen)}
       onOpenChange={props.onOpenChange}

--- a/packages/armory-sdk/src/lib/types/vault.ts
+++ b/packages/armory-sdk/src/lib/types/vault.ts
@@ -130,6 +130,7 @@ export type AddressIndex = z.infer<typeof AddressIndex>
 export const DeriveAccountRequest = z.object({
   keyId: z.string(),
   derivationPaths: z.array(DerivationPath).optional(),
+  count: z.number().optional(),
   accessToken: AccessToken
 })
 export type DeriveAccountRequest = z.infer<typeof DeriveAccountRequest>

--- a/packages/policy-engine-shared/src/lib/util/entity.util.ts
+++ b/packages/policy-engine-shared/src/lib/util/entity.util.ts
@@ -227,3 +227,13 @@ export const updateUserAccounts = (
     userAccounts: [...notAssignedToUser, ...userAccounts]
   }
 }
+
+export const addAccount = (entities: Entities, account: AccountEntity): Entities => ({
+  ...entities,
+  accounts: [...entities.accounts, account]
+})
+
+export const addAccounts = (entities: Entities, accounts: AccountEntity[]): Entities => ({
+  ...entities,
+  accounts: [...entities.accounts, ...accounts]
+})


### PR DESCRIPTION
This PR repurposes the `CreateWalletModal` into two new dialogs to generate a wallet and derive accounts in the Entity manager.

<div>
    <a href="https://www.loom.com/share/172e9d4f7a43405e88dbf1517464f794">
      <p>Demo Wallet Generation and Accounts Derivation - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/172e9d4f7a43405e88dbf1517464f794">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/172e9d4f7a43405e88dbf1517464f794-a320bb64e9248eb2-full-play.gif">
    </a>
  </div>

I've also removed icons from section buttons to remove the amount of noise on screen.

![image](https://github.com/user-attachments/assets/ba765c8b-78c5-4227-b37b-9530d3fbbcd3)

![image](https://github.com/user-attachments/assets/a7b1f965-27a6-45cf-b093-b59f69128885)
