### PR TITLE
Support checkIntentTypedDataMessage Criterion

### DIFF
--- a/apps/policy-engine/src/engine/__test__/e2e/evaluation.spec.ts
+++ b/apps/policy-engine/src/engine/__test__/e2e/evaluation.spec.ts
@@ -215,6 +215,17 @@ describe('Evaluation', () => {
                   verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
                   version: '1'
                 },
+                message: {
+                  from: {
+                    name: 'Alice',
+                    account: FIXTURE.VIEM_ACCOUNT.Alice.address
+                  },
+                  to: {
+                    name: 'Bob',
+                    account: FIXTURE.VIEM_ACCOUNT.Bob.address
+                  },
+                  contents: "Dear Bob, today we're going to the moon"
+                },
                 type: 'signTypedData'
               }
             }),

--- a/apps/policy-engine/src/engine/__test__/e2e/evaluation.spec.ts
+++ b/apps/policy-engine/src/engine/__test__/e2e/evaluation.spec.ts
@@ -209,22 +209,36 @@ describe('Evaluation', () => {
             }),
             ...(payload.request.action === Action.SIGN_TYPED_DATA && {
               transactionRequestIntent: {
-                domain: {
-                  chainId: 1,
-                  name: 'Ether Mail',
-                  verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-                  version: '1'
-                },
-                message: {
-                  from: {
-                    name: 'Alice',
-                    account: FIXTURE.VIEM_ACCOUNT.Alice.address
+                typedData: {
+                  domain: {
+                    name: 'Ether Mail',
+                    version: '1',
+                    chainId: 1,
+                    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
                   },
-                  to: {
-                    name: 'Bob',
-                    account: FIXTURE.VIEM_ACCOUNT.Bob.address
+                  primaryType: 'Mail',
+                  types: {
+                    Person: [
+                      { name: 'name', type: 'string' },
+                      { name: 'account', type: 'address' }
+                    ],
+                    Mail: [
+                      { name: 'from', type: 'Person' },
+                      { name: 'to', type: 'Person' },
+                      { name: 'contents', type: 'string' }
+                    ]
                   },
-                  contents: "Dear Bob, today we're going to the moon"
+                  message: {
+                    from: {
+                      name: 'Alice',
+                      account: FIXTURE.VIEM_ACCOUNT.Alice.address
+                    },
+                    to: {
+                      name: 'Bob',
+                      account: FIXTURE.VIEM_ACCOUNT.Bob.address
+                    },
+                    contents: "Dear Bob, today we're going to the moon"
+                  }
                 },
                 type: 'signTypedData'
               }

--- a/apps/policy-engine/src/open-policy-agent/core/__test__/unit/open-policy-agent.engine.spec.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/__test__/unit/open-policy-agent.engine.spec.ts
@@ -4,6 +4,7 @@ import {
   Criterion,
   Decision,
   Entities,
+  Eip712TypedData,
   EntityType,
   EvaluationRequest,
   FIXTURE,
@@ -561,77 +562,77 @@ describe('OpenPolicyAgentEngine', () => {
       })
     })
     describe('checkIntentTypedDataMessage', () => {
-      const immortalTypedData = {
-        types: {
-          EIP712Domain: [
+      const immutableTypedData = {
+        "types": {
+          "EIP712Domain": [
             {
-              name: 'chainId',
-              type: 'uint256'
+              "name": 'chainId',
+              "type": 'uint256'
             }
           ],
-          LinkWallet: [
+          "LinkWallet": [
             {
-              name: 'walletAddress',
-              type: 'address'
+              "name": 'walletAddress',
+              "type": 'address'
             },
             {
-              name: 'immutablePassportAddress',
-              type: 'address'
+              "name": 'immutablePassportAddress',
+              "type": 'address'
             },
             {
-              name: 'condition',
-              type: 'string'
+              "name": 'condition',
+              "type": 'string'
             },
             {
-              name: 'nonce',
-              type: 'string'
+              "name": 'nonce',
+              "type": 'string'
             }
           ]
         },
-        primaryType: 'LinkWallet',
-        domain: {
-          chainId: 1
+        "primaryType": 'LinkWallet',
+        "domain": {
+          "chainId": "1"
         },
-        message: {
-          walletAddress: '0x299697552cd035afd7e08600c4001fff48498263',
-          immutablePassportAddress: '0xfa9582594f460d3cad2095f6270996ac25f89874',
-          condition: 'I agree to link this wallet to my Immutable Passport account.',
-          nonce: 'mTu2kYHDG9jt9ZTIp'
+        "message": {
+          "walletAddress": '0x299697552cd035afd7e08600c4001fff48498263',
+          "immutablePassportAddress": '0xfa9582594f460d3cad2095f6270996ac25f89874',
+          "condition": 'I agree to link this wallet to my Immutable Passport account.',
+          "nonce": 'mTu2kYHDG9jt9ZTIp'
         }
-      }
+      } as unknown as Eip712TypedData
 
-      it('permits Immortal log-in typed data with message.condition policy and assigned account', async () => {
-        const immortalPolicy: Policy[] = [
+      it('permits Immutable log-in typed data with message.condition policy and assigned account', async () => {
+        const immutablePolicy: Policy[] = [
           {
-            id: 'test-permit-login-uid',
-            then: Then.PERMIT,
-            description: 'permits immortal login with assigned account',
-            when: [
+            "id": 'test-permit-login-uid',
+            "then": "permit",
+            "description": 'permits immutable login with assigned account',
+            "when": [
               {
-                criterion: Criterion.CHECK_INTENT_TYPED_DATA_MESSAGE,
-                args: [
+                "criterion": "checkIntentTypedDataMessage",
+                "args": [
                   [
                     {
-                      key: 'condition',
-                      value: 'I agree to link this wallet to my Immutable Passport account.'
+                      "key": 'condition',
+                      "value": 'I agree to link this wallet to my Immutable Passport account.'
                     }
                   ]
                 ]
               },
               {
-                criterion: Criterion.CHECK_ACCOUNT_ASSIGNED,
-                args: null
+                "criterion": "checkAccountAssigned",
+                "args": null
               }
             ]
           }
         ]
 
-        const e = await engine.setPolicies(immortalPolicy).setEntities(FIXTURE.ENTITIES).load()
+        const e = await engine.setPolicies(immutablePolicy).setEntities(FIXTURE.ENTITIES).load()
 
         const request = {
           action: Action.SIGN_TYPED_DATA,
           nonce: 'test-nonce',
-          typedData: immortalTypedData,
+          typedData: immutableTypedData,
           resourceId: FIXTURE.ACCOUNT.Testing.id
         }
 

--- a/apps/policy-engine/src/open-policy-agent/core/__test__/unit/open-policy-agent.engine.spec.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/__test__/unit/open-policy-agent.engine.spec.ts
@@ -563,65 +563,65 @@ describe('OpenPolicyAgentEngine', () => {
     })
     describe('checkIntentTypedDataMessage', () => {
       const immutableTypedData = {
-        "types": {
-          "EIP712Domain": [
+        types: {
+          EIP712Domain: [
             {
-              "name": 'chainId',
-              "type": 'uint256'
+              name: 'chainId',
+              type: 'uint256'
             }
           ],
-          "LinkWallet": [
+          LinkWallet: [
             {
-              "name": 'walletAddress',
-              "type": 'address'
+              name: 'walletAddress',
+              type: 'address'
             },
             {
-              "name": 'immutablePassportAddress',
-              "type": 'address'
+              name: 'immutablePassportAddress',
+              type: 'address'
             },
             {
-              "name": 'condition',
-              "type": 'string'
+              name: 'condition',
+              type: 'string'
             },
             {
-              "name": 'nonce',
-              "type": 'string'
+              name: 'nonce',
+              type: 'string'
             }
           ]
         },
-        "primaryType": 'LinkWallet',
-        "domain": {
-          "chainId": "1"
+        primaryType: 'LinkWallet',
+        domain: {
+          chainId: '1'
         },
-        "message": {
-          "walletAddress": '0x299697552cd035afd7e08600c4001fff48498263',
-          "immutablePassportAddress": '0xfa9582594f460d3cad2095f6270996ac25f89874',
-          "condition": 'I agree to link this wallet to my Immutable Passport account.',
-          "nonce": 'mTu2kYHDG9jt9ZTIp'
+        message: {
+          walletAddress: '0x299697552cd035afd7e08600c4001fff48498263',
+          immutablePassportAddress: '0xfa9582594f460d3cad2095f6270996ac25f89874',
+          condition: 'I agree to link this wallet to my Immutable Passport account.',
+          nonce: 'mTu2kYHDG9jt9ZTIp'
         }
       } as unknown as Eip712TypedData
 
       it('permits Immutable log-in typed data with message.condition policy and assigned account', async () => {
         const immutablePolicy: Policy[] = [
           {
-            "id": 'test-permit-login-uid',
-            "then": "permit",
-            "description": 'permits immutable login with assigned account',
-            "when": [
+            id: 'test-permit-login-uid',
+            then: 'permit',
+            description: 'permits immutable login with assigned account',
+            when: [
               {
-                "criterion": "checkIntentTypedDataMessage",
-                "args": [
+                criterion: 'checkIntentTypedDataMessage',
+                args: [
                   [
                     {
-                      "key": 'condition',
-                      "value": 'I agree to link this wallet to my Immutable Passport account.'
+                      key: 'condition',
+                      value: 'I agree to link this wallet to my Immutable Passport account.'
                     }
                   ]
                 ]
               },
               {
-                "criterion": "checkAccountAssigned",
-                "args": null
+                criterion: 'checkAccountAssigned',
+                args: null
               }
             ]
           }

--- a/apps/policy-engine/src/open-policy-agent/core/__test__/unit/open-policy-agent.engine.spec.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/__test__/unit/open-policy-agent.engine.spec.ts
@@ -3,8 +3,8 @@ import {
   Action,
   Criterion,
   Decision,
-  Entities,
   Eip712TypedData,
+  Entities,
   EntityType,
   EvaluationRequest,
   FIXTURE,
@@ -381,6 +381,7 @@ describe('OpenPolicyAgentEngine', () => {
       })
     })
   })
+
   describe('scenario testing', () => {
     describe('checkDestinationClassification', () => {
       // Sample policy & data for this specific set of

--- a/apps/policy-engine/src/open-policy-agent/core/__test__/unit/open-policy-agent.engine.spec.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/__test__/unit/open-policy-agent.engine.spec.ts
@@ -633,7 +633,7 @@ describe('OpenPolicyAgentEngine', () => {
           action: Action.SIGN_TYPED_DATA,
           nonce: 'test-nonce',
           typedData: immutableTypedData,
-          resourceId: FIXTURE.ACCOUNT.Testing.id
+          resourceId: 'eip155:eoa:0x0f610AC9F0091f8F573c33f15155afE8aD747495'
         }
 
         const evaluation: EvaluationRequest = {

--- a/apps/policy-engine/src/open-policy-agent/core/type/open-policy-agent.type.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/type/open-policy-agent.type.ts
@@ -1,15 +1,15 @@
 import {
-  AccountEntity,
-  AccountGroupEntity,
   Action,
-  AddressBookAccountEntity,
   CredentialEntity,
   Feed,
   SerializedTransactionRequest,
   SerializedUserOperationV6,
-  TokenEntity,
-  UserEntity,
-  UserGroupEntity
+  accountEntitySchema,
+  accountGroupEntitySchema,
+  addressBookAccountEntitySchema,
+  tokenEntitySchema,
+  userEntitySchema,
+  userGroupEntitySchema
 } from '@narval/policy-engine-shared'
 import { Intent } from '@narval/transaction-request-intent'
 import { loadPolicy } from '@open-policy-agent/opa-wasm'
@@ -35,27 +35,47 @@ export type Input = {
 // TODO: (@wcalderipe, 18/03/24) Check with @samteb how can we replace these
 // types by entities defined at @narval/policy-engine-shared.
 
-export type UserGroup = UserGroupEntity & {
-  users: string[] // userIds
-}
+const Id = z.string().toLowerCase()
 
-export type Account = AccountEntity & {
-  assignees: string[] // userIds
-}
+export const UserGroup = userGroupEntitySchema.extend({
+  id: Id,
+  users: z.array(Id)
+})
+export type UserGroup = z.infer<typeof UserGroup>
 
-export type AccountGroup = AccountGroupEntity & {
-  accounts: string[] // accountIds
-}
+export const Account = accountEntitySchema.extend({
+  id: Id,
+  assignees: z.array(Id)
+})
+export type Account = z.infer<typeof Account>
 
-export type Data = {
-  entities: {
-    addressBook: Record<string, AddressBookAccountEntity>
-    tokens: Record<string, TokenEntity>
-    users: Record<string, UserEntity>
-    userGroups: Record<string, UserGroup>
-    accounts: Record<string, Account>
-    accountGroups: Record<string, AccountGroupEntity>
-  }
-}
+export const AccountGroup = accountGroupEntitySchema.extend({
+  id: Id,
+  accounts: z.array(Id)
+})
+export type AccountGroup = z.infer<typeof AccountGroup>
+
+// export type Data = {
+//   entities: {
+//     addressBook: Record<string, AddressBookAccountEntity>
+//     tokens: Record<string, TokenEntity>
+//     users: Record<string, UserEntity>
+//     userGroups: Record<string, UserGroup>
+//     accounts: Record<string, Account>
+//     accountGroups: Record<string, AccountGroupEntity>
+//   }
+// }
+
+export const Data = z.object({
+  entities: z.object({
+    addressBook: z.record(Id, addressBookAccountEntitySchema.extend({ id: Id })),
+    tokens: z.record(Id, tokenEntitySchema.extend({ id: Id })),
+    users: z.record(Id, userEntitySchema.extend({ id: Id })),
+    accountGroups: z.record(Id, AccountGroup),
+    userGroups: z.record(Id, UserGroup),
+    accounts: z.record(Id, Account)
+  })
+})
+export type Data = z.infer<typeof Data>
 
 export type Result = z.infer<typeof resultSchema>

--- a/apps/policy-engine/src/open-policy-agent/core/type/open-policy-agent.type.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/type/open-policy-agent.type.ts
@@ -35,6 +35,8 @@ export type Input = {
 // TODO: (@wcalderipe, 18/03/24) Check with @samteb how can we replace these
 // types by entities defined at @narval/policy-engine-shared.
 
+// IMPORTANT: Index entities by lower case ID is an important invariant for
+// many Rego rules performing a look up on the dataset.
 const Id = z.string().toLowerCase()
 
 export const UserGroup = userGroupEntitySchema.extend({
@@ -54,17 +56,6 @@ export const AccountGroup = accountGroupEntitySchema.extend({
   accounts: z.array(Id)
 })
 export type AccountGroup = z.infer<typeof AccountGroup>
-
-// export type Data = {
-//   entities: {
-//     addressBook: Record<string, AddressBookAccountEntity>
-//     tokens: Record<string, TokenEntity>
-//     users: Record<string, UserEntity>
-//     userGroups: Record<string, UserGroup>
-//     accounts: Record<string, Account>
-//     accountGroups: Record<string, AccountGroupEntity>
-//   }
-// }
 
 export const Data = z.object({
   entities: z.object({

--- a/apps/policy-engine/src/open-policy-agent/core/util/__test__/unit/evaluation.util.spec.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/util/__test__/unit/evaluation.util.spec.ts
@@ -63,11 +63,11 @@ describe('toInput', () => {
       expect(input.principal).toEqual(principal)
     })
 
-    it('maps resource', () => {
+    it('maps resource uid to lower case', () => {
       const input = toInput({ evaluation, principal, approvals })
       const request = evaluation.request as SignTransactionAction
 
-      expect(input.resource).toEqual({ uid: request.resourceId })
+      expect(input.resource).toEqual({ uid: request.resourceId.toLowerCase() })
     })
 
     it('maps approvals', () => {
@@ -115,11 +115,11 @@ describe('toInput', () => {
       expect(input.principal).toEqual(principal)
     })
 
-    it('maps resource', () => {
+    it('maps resource uid to lower case', () => {
       const input = toInput({ evaluation, principal, approvals })
       const request = evaluation.request as SignTransactionAction
 
-      expect(input.resource).toEqual({ uid: request.resourceId })
+      expect(input.resource).toEqual({ uid: request.resourceId.toLowerCase() })
     })
 
     it('maps approvals', () => {
@@ -160,11 +160,11 @@ describe('toInput', () => {
       expect(input.principal).toEqual(principal)
     })
 
-    it('maps resource', () => {
+    it('maps resource uid to lower case', () => {
       const input = toInput({ evaluation, principal, approvals })
       const request = evaluation.request as SignMessageAction
 
-      expect(input.resource).toEqual({ uid: request.resourceId })
+      expect(input.resource).toEqual({ uid: request.resourceId.toLowerCase() })
     })
 
     it('maps approvals', () => {
@@ -193,11 +193,11 @@ describe('toInput', () => {
       expect(input.principal).toEqual(principal)
     })
 
-    it('maps resource', () => {
+    it('maps resource uid to lower case', () => {
       const input = toInput({ evaluation, principal, approvals })
       const request = evaluation.request as SignRawAction
 
-      expect(input.resource).toEqual({ uid: request.resourceId })
+      expect(input.resource).toEqual({ uid: request.resourceId.toLowerCase() })
     })
 
     it('maps approvals', () => {
@@ -226,11 +226,11 @@ describe('toInput', () => {
       expect(input.principal).toEqual(principal)
     })
 
-    it('maps resource', () => {
+    it('maps resource uid to lower case', () => {
       const input = toInput({ evaluation, principal, approvals })
       const request = evaluation.request as GrantPermissionAction
 
-      expect(input.resource).toEqual({ uid: request.resourceId })
+      expect(input.resource).toEqual({ uid: request.resourceId.toLowerCase() })
     })
 
     it('maps approvals', () => {
@@ -246,6 +246,7 @@ describe('toInput', () => {
       expect(input.permissions).toEqual(request.permissions)
     })
   })
+
   describe(`when action is ${Action.SIGN_USER_OPERATION}`, () => {
     let evaluation: EvaluationRequest
 
@@ -265,11 +266,11 @@ describe('toInput', () => {
       expect(input.principal).toEqual(principal)
     })
 
-    it('maps resource', () => {
+    it('maps resource uid to lower case', () => {
       const input = toInput({ evaluation, principal, approvals })
       const request = evaluation.request as SignUserOperationAction
 
-      expect(input.resource).toEqual({ uid: request.resourceId })
+      expect(input.resource).toEqual({ uid: request.resourceId.toLowerCase() })
     })
 
     it('maps approvals', () => {

--- a/apps/policy-engine/src/open-policy-agent/core/util/__test__/unit/evaluation.util.spec.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/util/__test__/unit/evaluation.util.spec.ts
@@ -289,11 +289,13 @@ describe('toInput', () => {
 
 describe('toData', () => {
   describe('entities', () => {
+    const lowerCaseId = <T extends { id: string }>(value: T) => ({ ...value, id: value.id.toLowerCase() })
+
     it('indexes address book accounts by lower case id', () => {
       const { entities } = toData(FIXTURE.ENTITIES)
       const firstAccount = FIXTURE.ADDRESS_BOOK[0]
 
-      expect(entities.addressBook[firstAccount.id.toLowerCase()]).toEqual(firstAccount)
+      expect(entities.addressBook[firstAccount.id.toLowerCase()]).toEqual(lowerCaseId(firstAccount))
     })
 
     it('indexes tokens by lower case id', () => {
@@ -314,7 +316,10 @@ describe('toData', () => {
       const { entities } = toData(FIXTURE.ENTITIES)
       const account = FIXTURE.ACCOUNT.Testing
 
-      expect(entities.accounts[account.id.toLowerCase()]).toEqual({ ...account, assignees: ['test-alice-user-uid'] })
+      expect(entities.accounts[account.id.toLowerCase()]).toEqual({
+        ...lowerCaseId(account),
+        assignees: ['test-alice-user-uid']
+      })
     })
 
     it('indexes user groups with members by lower case id', () => {
@@ -322,8 +327,10 @@ describe('toData', () => {
       const group = FIXTURE.USER_GROUP.Engineering
 
       expect(entities.userGroups[group.id.toLowerCase()]).toEqual({
-        id: group.id,
-        users: FIXTURE.USER_GROUP_MEMBER.filter(({ groupId }) => groupId === group.id).map(({ userId }) => userId)
+        id: group.id.toLowerCase(),
+        users: FIXTURE.USER_GROUP_MEMBER.filter(({ groupId }) => groupId === group.id).map(({ userId }) =>
+          userId.toLowerCase()
+        )
       })
     })
 
@@ -332,9 +339,9 @@ describe('toData', () => {
       const group = FIXTURE.ACCOUNT_GROUP.Treasury
 
       expect(entities.accountGroups[group.id.toLowerCase()]).toEqual({
-        id: group.id,
-        accounts: FIXTURE.ACCOUNT_GROUP_MEMBER.filter(({ groupId }) => groupId === group.id).map(
-          ({ accountId }) => accountId
+        id: group.id.toLowerCase(),
+        accounts: FIXTURE.ACCOUNT_GROUP_MEMBER.filter(({ groupId }) => groupId === group.id).map(({ accountId }) =>
+          accountId.toLowerCase()
         )
       })
     })

--- a/apps/policy-engine/src/open-policy-agent/core/util/evaluation.util.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/util/evaluation.util.ts
@@ -16,7 +16,7 @@ import {
 } from '@narval/policy-engine-shared'
 import { InputType, safeDecode } from '@narval/transaction-request-intent'
 import { HttpStatus } from '@nestjs/common'
-import { indexBy, toLower } from 'lodash/fp'
+import { indexBy } from 'lodash/fp'
 import { OpenPolicyAgentException } from '../exception/open-policy-agent.exception'
 import { Account, AccountGroup, Data, Input, UserGroup } from '../type/open-policy-agent.type'
 
@@ -173,10 +173,6 @@ export const toInput = (params: {
   })
 }
 
-// NOTE: Index entities by lower case ID is an important invariant for many
-// Rego rules performing a look up on the dataset.
-const index = <Entity extends { id: string }>(entities: Entity[]) => indexBy(({ id }) => toLower(id), entities)
-
 export const toData = (entities: Entities): Data => {
   const userGroups = entities.userGroupMembers.reduce((groups, { userId, groupId }) => {
     const id = groupId.toLowerCase()
@@ -220,14 +216,18 @@ export const toData = (entities: Entities): Data => {
     }
   }, new Map<string, AccountGroup>())
 
-  return {
+  const data: Data = {
     entities: {
-      addressBook: index(entities.addressBook),
-      tokens: index(entities.tokens),
-      users: index(entities.users),
+      addressBook: indexBy('id', entities.addressBook),
+      tokens: indexBy('id', entities.tokens),
+      users: indexBy('id', entities.users),
       userGroups: Object.fromEntries(userGroups),
-      accounts: index(accounts),
+      accounts: indexBy('id', accounts),
       accountGroups: Object.fromEntries(accountGroups)
     }
   }
+
+  // IMPORTANT: The Data schema converts IDs to lower case because we don't
+  // want to be doing defensive programming in Rego.
+  return Data.parse(data)
 }

--- a/apps/policy-engine/src/open-policy-agent/core/util/evaluation.util.ts
+++ b/apps/policy-engine/src/open-policy-agent/core/util/evaluation.util.ts
@@ -163,7 +163,10 @@ export const toInput = (params: {
   const mapper = mappers.get(action)
 
   if (mapper) {
-    return mapper(evaluation.request, params.principal, params.approvals, evaluation.feeds)
+    return {
+      ...mapper(evaluation.request, params.principal, params.approvals, evaluation.feeds),
+      resource: { uid: evaluation.request.resourceId.toLowerCase() }
+    }
   }
 
   throw new OpenPolicyAgentException({

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/assigned_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/assigned_test.rego
@@ -1,0 +1,9 @@
+package main
+
+test_assigned_account {
+  checkAccountAssigned with input as requestWithEip1559Transaction with data.entities as entities
+}
+
+test_assigned_lowercase {
+  checkAccountAssigned with input as requestWithUpperCasedResource with data.entities as entities
+}

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/assigned_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/assigned_test.rego
@@ -3,7 +3,3 @@ package main
 test_assigned_account {
   checkAccountAssigned with input as requestWithEip1559Transaction with data.entities as entities
 }
-
-test_assigned_lowercase {
-  checkAccountAssigned with input as requestWithUpperCasedResource with data.entities as entities
-}

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/signMessage_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/signMessage_test.rego
@@ -40,12 +40,14 @@ test_checkSignTypedData {
 		"resource": {"uid": "eip155:eoa:0xddcf208f219a6e6af072f2cfdc615b2c1805f98e"},
 		"intent": {
 			"type": "signTypedData",
-			"domain": {
-				"version": "2",
-				"chainId": 137,
-				"name": "LINK",
-				"verifyingContract": "eip155:137:0xa45e21e9370ba031c5e1f47dedca74a7ce2ed7a3",
-			}
+      "typedData": {
+        "domain": {
+			  	"version": "2",
+			  	"chainId": 137,
+			  	"name": "LINK",
+			  	"verifyingContract": "eip155:137:0xa45e21e9370ba031c5e1f47dedca74a7ce2ed7a3",
+			  },
+      }
 		}
 	})
 	checkAction({"signTypedData"}) with input as signTypedDataRequest with data.entities as entities

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/typedDataMessage_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/typedDataMessage_test.rego
@@ -1,28 +1,29 @@
 package main
 
-typedData := {
+typedDataInput = {
     "typedData": {
         "message": {
-            "greeting": "Hello world",
-            "farewell": "Goodbye world",
+            "walletAddress": "0x299697552cd035afd7e08600c4001fff48498263",
+            "immutablePassportAddress": "0xfa9582594f460d3cad2095f6270996ac25f89874",
+            "condition": "I agree to link this wallet to my Immutable Passport account.",
+            "nonce": "mTu2kYHDG9jt9ZTIp"
         }
     }
 }
 
 test_checkIntentTypedDataMessageCondition {
-    conditions := [
-        [{"key": "greeting", "value": "Hello world"}],
-        [{"key": "farewell", "value": "Goodbye world"}],
+    filters := [
+        [{"key": "condition", "value": "I agree to link this wallet to my Immutable Passport account."}],
     ]
 
-    checkIntentTypedDataMessageCondition(conditions) with input as typedData
+    typedDataMessageCondition(filters) with input as typedDataInput with data.entities as entities
 }
 
 test_checkIntentTypedDataMessageCondition_fail {
     conditions := [
-        [{"key": "greeting", "value": "Hello world"}],
-        [{"key": "farewell", "value": "Hello world"}], 
+        [{"key": "condition", "value": "I agree to link this wallet to my Immutable Passport account."}, {"key": "walletAddress", "value": "0xwrongaddress"}],
+        [],
     ]
 
-    not checkIntentTypedDataMessageCondition(conditions) with input as typedData
+    not typedDataMessageCondition(conditions) with input as typedDataInput with data.entities as entities
 }

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/typedDataMessage_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/typedDataMessage_test.rego
@@ -1,29 +1,69 @@
 package main
 
 typedDataInput = {
-    "typedData": {
-        "message": {
-            "walletAddress": "0x299697552cd035afd7e08600c4001fff48498263",
-            "immutablePassportAddress": "0xfa9582594f460d3cad2095f6270996ac25f89874",
-            "condition": "I agree to link this wallet to my Immutable Passport account.",
-            "nonce": "mTu2kYHDG9jt9ZTIp"
+      "action": "signTypedData",
+      "principal": {
+        "userId": "test-alice-user-uid",
+        "id": "0x4fca4ebdd44d54a470a273cb6c131303892cb754f0d374a860fab7936bb95d94",
+        "key": {
+          "kty": "EC",
+          "alg": "ES256K",
+          "kid": "0x4fca4ebdd44d54a470a273cb6c131303892cb754f0d374a860fab7936bb95d94",
+          "crv": "secp256k1",
+          "x": "zb-LwlHDtp5sV8E33k3H2TCm-LNTGIcFjODNWI4gHRY",
+          "y": "6Pbt6dwxAeS7yHp7YV2GbXs_Px0tWrTfeTv9erjC7zs"
         }
+      },
+      "approvals": [
+        {
+          "userId": "test-alice-user-uid",
+          "id": "0x4fca4ebdd44d54a470a273cb6c131303892cb754f0d374a860fab7936bb95d94",
+          "key": {
+            "kty": "EC",
+            "alg": "ES256K",
+            "kid": "0x4fca4ebdd44d54a470a273cb6c131303892cb754f0d374a860fab7936bb95d94",
+            "crv": "secp256k1",
+            "x": "zb-LwlHDtp5sV8E33k3H2TCm-LNTGIcFjODNWI4gHRY",
+            "y": "6Pbt6dwxAeS7yHp7YV2GbXs_Px0tWrTfeTv9erjC7zs"
+          }
+        }
+      ],
+      "intent": {
+        "type": "signTypedData",
+        "domain": {
+          "chainId": 1
+        },
+        "message": {
+          "walletAddress": "0x299697552cd035afd7e08600c4001fff48498263",
+          "immutablePassportAddress": "0xfa9582594f460d3cad2095f6270996ac25f89874",
+          "condition": "I agree to link this wallet to my Immutable Passport account.",
+          "nonce": "mTu2kYHDG9jt9ZTIp"
+        }
+      },
+      "resource": {
+        "uid": "eip155:eoa:0x0f610AC9F0091f8F573c33f15155afE8aD747495"
+      }
     }
-}
 
 test_checkIntentTypedDataMessageCondition {
     filters := [
         [{"key": "condition", "value": "I agree to link this wallet to my Immutable Passport account."}],
     ]
 
-    typedDataMessageCondition(filters) with input as typedDataInput with data.entities as entities
+    checkIntentTypedDataMessage(filters) with input as typedDataInput with data.entities as entities
 }
 
-test_checkIntentTypedDataMessageCondition_fail {
+test_checkIntentTypedDataMessageCondition_one_wrong_value_one_correct_value_in_condition_should_not_match {
     conditions := [
-        [{"key": "condition", "value": "I agree to link this wallet to my Immutable Passport account."}, {"key": "walletAddress", "value": "0xwrongaddress"}],
-        [],
+        [ {"key": "walletAddress", "value": "0xwrongaddress"}, {"key": "condition", "value": "I agree to link this wallet to my Immutable Passport account."}],
     ]
+    not checkIntentTypedDataMessage(conditions) with input as typedDataInput with data.entities as entities
+}
 
-    not typedDataMessageCondition(conditions) with input as typedDataInput with data.entities as entities
+test_checkIntentTypedDataMessageCondition_one_wrong_condition_one_correct_condition_should_match {
+    conditions := [
+        [{"key": "condition", "value": "I agree to link this wallet to my Immutable Passport account."}],
+        [{"key": "wrongKey", "value": "0x299697552cd035afd7e08600c4001fff48498263"}]
+    ]
+    checkIntentTypedDataMessage(conditions) with input as typedDataInput with data.entities as entities
 }

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/typedDataMessage_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/typedDataMessage_test.rego
@@ -30,14 +30,43 @@ typedDataInput = {
       ],
       "intent": {
         "type": "signTypedData",
-        "domain": {
-          "chainId": 1
-        },
-        "message": {
-          "walletAddress": "0x299697552cd035afd7e08600c4001fff48498263",
-          "immutablePassportAddress": "0xfa9582594f460d3cad2095f6270996ac25f89874",
-          "condition": "I agree to link this wallet to my Immutable Passport account.",
-          "nonce": "mTu2kYHDG9jt9ZTIp"
+        "typedData": {
+          "types": {
+            "EIP712Domain": [
+              {
+                "name": "chainId",
+                "type": "uint256"
+              }
+            ],
+            "LinkWallet": [
+              {
+                "name": "walletAddress",
+                "type": "address"
+              },
+              {
+                "name": "immutablePassportAddress",
+                "type": "address"
+              },
+              {
+                "name": "condition",
+                "type": "string"
+              },
+              {
+                "name": "nonce",
+                "type": "string"
+              }
+            ]
+          },
+          "primaryType": "LinkWallet",
+          "domain": {
+            "chainId": "1"
+          },
+          "message": {
+            "walletAddress": "0x299697552cd035afd7e08600c4001fff48498263",
+            "immutablePassportAddress": "0xfa9582594f460d3cad2095f6270996ac25f89874",
+            "condition": "I agree to link this wallet to my Immutable Passport account.",
+            "nonce": "mTu2kYHDG9jt9ZTIp"
+          }
         }
       },
       "resource": {

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/typedDataMessage_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/typedDataMessage_test.rego
@@ -1,0 +1,28 @@
+package main
+
+typedData := {
+    "typedData": {
+        "message": {
+            "greeting": "Hello world",
+            "farewell": "Goodbye world",
+        }
+    }
+}
+
+test_checkIntentTypedDataMessageCondition {
+    conditions := [
+        [{"key": "greeting", "value": "Hello world"}],
+        [{"key": "farewell", "value": "Goodbye world"}],
+    ]
+
+    checkIntentTypedDataMessageCondition(conditions) with input as typedData
+}
+
+test_checkIntentTypedDataMessageCondition_fail {
+    conditions := [
+        [{"key": "greeting", "value": "Hello world"}],
+        [{"key": "farewell", "value": "Hello world"}], 
+    ]
+
+    not checkIntentTypedDataMessageCondition(conditions) with input as typedData
+}

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/resource_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/resource_test.rego
@@ -15,10 +15,18 @@ test_resource {
 	accountGroupsById = getAccountGroups("eip155:eoa:0xddcf208f219a6e6af072f2cfdc615b2c1805f98e") with input as requestWithEip1559Transaction with data.entities as entities
 	accountGroupsById == {"test-account-group-one-uid"}
 
-	checkAccountAssigned with input as requestWithEip1559Transaction with data.entities as entities
-
 	checkAccountId({"eip155:eoa:0xddcf208f219a6e6af072f2cfdc615b2c1805f98e"}) with input as requestWithEip1559Transaction with data.entities as entities
 	checkAccountAddress({"0xddcf208f219a6e6af072f2cfdc615b2c1805f98e"}) with input as requestWithEip1559Transaction with data.entities as entities
 	checkAccountType({"eoa"}) with input as requestWithEip1559Transaction with data.entities as entities
 	checkAccountGroup({"test-account-group-one-uid"}) with input as requestWithEip1559Transaction with data.entities as entities
+}
+
+test_upperCaseResource {
+  account = resource with input as requestWithUpperCasedResource with data.entities as entities
+  account == {
+    "id": "eip155:eoa:0xddcf208f219a6e6af072f2cfdc615b2c1805f98e",
+    "address": "0xddcf208f219a6e6af072f2cfdc615b2c1805f98e",
+    "accountType": "eoa",
+    "assignees": ["test-bob-uid", "test-alice-uid", "test-foo-uid", "test-bar-uid"],
+  }
 }

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/resource_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/resource_test.rego
@@ -20,13 +20,3 @@ test_resource {
 	checkAccountType({"eoa"}) with input as requestWithEip1559Transaction with data.entities as entities
 	checkAccountGroup({"test-account-group-one-uid"}) with input as requestWithEip1559Transaction with data.entities as entities
 }
-
-test_upperCaseResource {
-  account = resource with input as requestWithUpperCasedResource with data.entities as entities
-  account == {
-    "id": "eip155:eoa:0xddcf208f219a6e6af072f2cfdc615b2c1805f98e",
-    "address": "0xddcf208f219a6e6af072f2cfdc615b2c1805f98e",
-    "accountType": "eoa",
-    "assignees": ["test-bob-uid", "test-alice-uid", "test-foo-uid", "test-bar-uid"],
-  }
-}

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/main_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/main_test.rego
@@ -24,6 +24,8 @@ principalReq = {"userId": "test-bob-uid"}
 
 resourceReq = {"uid": "eip155:eoa:0xddcf208f219a6e6af072f2cfdc615b2c1805f98e"}
 
+upperCaseResourceReq = {"uid": "eip155:eoa:0xDDCF208F219A6E6AF072F2CFDC615B2C1805F98E"}
+
 transactionRequestEIP1559 = {
 	"from": "0xddcf208f219a6e6af072f2cfdc615b2c1805f98e",
 	"to": "0xa45e21e9370ba031c5e1f47dedca74a7ce2ed7a3",
@@ -135,6 +137,16 @@ requestWithLegacyTransaction = {
   "transactionRequest": transactionRequestLegacy,
   "principal": principalReq,
   "resource": resourceReq,
+  "intent": intentReq,
+  "approvals": approvalsReq,
+  "feeds": feedsReq,
+}
+
+requestWithUpperCasedResource = {
+  "action": "signTransaction",
+  "transactionRequest": transactionRequestEIP1559,
+  "principal": principalReq,
+  "resource": upperCaseResourceReq,
   "intent": intentReq,
   "approvals": approvalsReq,
   "feeds": feedsReq,

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/main_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/main_test.rego
@@ -24,8 +24,6 @@ principalReq = {"userId": "test-bob-uid"}
 
 resourceReq = {"uid": "eip155:eoa:0xddcf208f219a6e6af072f2cfdc615b2c1805f98e"}
 
-upperCaseResourceReq = {"uid": "eip155:eoa:0xDDCF208F219A6E6AF072F2CFDC615B2C1805F98E"}
-
 transactionRequestEIP1559 = {
 	"from": "0xddcf208f219a6e6af072f2cfdc615b2c1805f98e",
 	"to": "0xa45e21e9370ba031c5e1f47dedca74a7ce2ed7a3",
@@ -137,16 +135,6 @@ requestWithLegacyTransaction = {
   "transactionRequest": transactionRequestLegacy,
   "principal": principalReq,
   "resource": resourceReq,
-  "intent": intentReq,
-  "approvals": approvalsReq,
-  "feeds": feedsReq,
-}
-
-requestWithUpperCasedResource = {
-  "action": "signTransaction",
-  "transactionRequest": transactionRequestEIP1559,
-  "principal": principalReq,
-  "resource": upperCaseResourceReq,
   "intent": intentReq,
   "approvals": approvalsReq,
   "feeds": feedsReq,

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/domain.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/domain.rego
@@ -19,29 +19,10 @@ checkDomainCondition(value, set) {
 }
 
 checkIntentDomain(filters) {
-	domain = object.union(wildcardIntentDomain, input.intent.domain)
+	domain = object.union(wildcardIntentDomain, input.intent.typedData.domain)
 	conditions = object.union(wildcardIntentDomain, filters)
 	checkDomainCondition(domain.version, conditions.version)
 	checkDomainCondition(numberToString(domain.chainId), conditions.chainId)
 	checkDomainCondition(domain.name, conditions.name)
 	checkDomainCondition(domain.verifyingContract, conditions.verifyingContract)
-}
-
-typedDataMessageKeyValueCheck(conditions) {
-  count(conditions) > 0
-	inputMessage = input.typedData.message
-    checkedConditions = [condition | 
-    	condition = conditions[_]
-        inputMessage[condition.key] == condition.value
-    ]
-    count(checkedConditions) == count(conditions)
-}
-
-typedDataMessageCondition(args) {
-  count(args) > 0
-	checkedArgs = [singleCondition | 
-    	singleCondition = args[_]
-        typedDataMessageKeyValueCheck(singleCondition)
-    ]
-  count(checkedArgs) > 0
 }

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/domain.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/domain.rego
@@ -26,3 +26,22 @@ checkIntentDomain(filters) {
 	checkDomainCondition(domain.name, conditions.name)
 	checkDomainCondition(domain.verifyingContract, conditions.verifyingContract)
 }
+
+typedDataMessageKeyValueCheck(conditions) {
+  count(conditions) > 0
+	inputMessage = input.typedData.message
+    checkedConditions = [condition | 
+    	condition = conditions[_]
+        inputMessage[condition.key] == condition.value
+    ]
+    count(checkedConditions) == count(conditions)
+}
+
+typedDataMessageCondition(args) {
+  count(args) > 0
+	checkedArgs = [singleCondition | 
+    	singleCondition = args[_]
+        typedDataMessageKeyValueCheck(singleCondition)
+    ]
+  count(checkedArgs) > 0
+}

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/message.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/message.rego
@@ -1,0 +1,20 @@
+package main
+
+typedDataMessageKeyValueCheck(conditions) {
+  count(conditions) > 0
+	inputMessage = input.typedData.message
+    checkedConditions = [condition | 
+    	condition = conditions[_]
+        inputMessage[condition.key] == condition.value
+    ]
+    count(checkedConditions) == count(conditions)
+}
+
+typedDataMessageCondition(args) {
+  count(args) > 0
+	checkedArgs = [singleCondition | 
+    	singleCondition = args[_]
+        typedDataMessageKeyValueCheck(singleCondition)
+    ]
+  count(checkedArgs) > 0
+}

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/message.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/message.rego
@@ -2,7 +2,7 @@ package main
 
 typedDataMessageKeyValueCheck(conditions) {
   count(conditions) > 0
-	inputMessage = input.intent.message
+	inputMessage = input.intent.typedData.message
     checkedConditions = [condition | 
     	condition = conditions[_]
         inputMessage[condition.key] == condition.value

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/message.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/intent/signTypedData/message.rego
@@ -2,7 +2,7 @@ package main
 
 typedDataMessageKeyValueCheck(conditions) {
   count(conditions) > 0
-	inputMessage = input.typedData.message
+	inputMessage = input.intent.message
     checkedConditions = [condition | 
     	condition = conditions[_]
         inputMessage[condition.key] == condition.value
@@ -10,7 +10,7 @@ typedDataMessageKeyValueCheck(conditions) {
     count(checkedConditions) == count(conditions)
 }
 
-typedDataMessageCondition(args) {
+checkIntentTypedDataMessage(args) {
   count(args) > 0
 	checkedArgs = [singleCondition | 
     	singleCondition = args[_]

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/resource.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/resource.rego
@@ -2,7 +2,7 @@ package main
 
 import future.keywords.in
 
-resource = data.entities.accounts[lower(input.resource.uid)]
+resource = data.entities.accounts[input.resource.uid]
 
 checkAccountAssigned {
 	account = data.entities.accounts[resource.id]

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/resource.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/criteria/resource.rego
@@ -2,7 +2,7 @@ package main
 
 import future.keywords.in
 
-resource = data.entities.accounts[input.resource.uid]
+resource = data.entities.accounts[lower(input.resource.uid)]
 
 checkAccountAssigned {
 	account = data.entities.accounts[resource.id]

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/account.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/account.rego
@@ -42,7 +42,7 @@ getDestination(intent) = entry {
 	# will return an AddressBook over Account.
 	#
 	# See https://docs.styra.com/opa/errors/eval-conflict-error/complete-rules-must-not-produce-multiple-outputs
-	not data.entities.addressBook[intent.to]
+	not data.entities.addressBook[toEntityId(intent.to)]
 
 	chainAccount = parseChainAccount(intent.to)
 	account = data.entities.accounts[_]

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/account.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/account.rego
@@ -42,7 +42,7 @@ getDestination(intent) = entry {
 	# will return an AddressBook over Account.
 	#
 	# See https://docs.styra.com/opa/errors/eval-conflict-error/complete-rules-must-not-produce-multiple-outputs
-	not data.entities.addressBook[toEntityId(intent.to)]
+	not data.entities.addressBook[intent.to]
 
 	chainAccount = parseChainAccount(intent.to)
 	account = data.entities.accounts[_]
@@ -53,7 +53,7 @@ getDestination(intent) = entry {
 	# INVARIANT: Every EOA Account is an implicity AddressBook on every chain
 	# which `classification` is always `managed`.
 	entry = {
-		"id": toEntityId(intent.to),
+		"id": intent.to,
 		"address": chainAccount.address,
 		"chainId": chainId,
 		"classification": "managed",

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/entities.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/entities.rego
@@ -32,5 +32,3 @@ getUserGroups(id) = {group.id |
 	group = data.entities.userGroups[_]
 	id in group.users
 }
-
-toEntityId(value) = lower(value)

--- a/packages/armory-sdk/src/lib/http/client/auth/api.ts
+++ b/packages/armory-sdk/src/lib/http/client/auth/api.ts
@@ -2045,7 +2045,7 @@ export type PolicyDataStoreDtoPolicyDataInnerThenEnum = typeof PolicyDataStoreDt
  * @type PolicyDataStoreDtoPolicyDataInnerWhenInner
  * @export
  */
-export type PolicyDataStoreDtoPolicyDataInnerWhenInner = PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf1 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf10 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf11 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf12 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf13 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf14 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf15 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf16 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf17 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf18 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf19 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf2 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf20 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf21 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf22 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf23 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf24 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf25 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf26 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf27 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf28 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf29 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf3 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf34 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf4 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf40 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf5 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf6 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf7 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf8 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf9;
+export type PolicyDataStoreDtoPolicyDataInnerWhenInner = PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf1 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf10 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf11 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf12 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf13 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf14 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf15 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf16 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf17 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf18 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf19 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf2 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf20 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf21 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf22 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf23 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf24 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf25 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf26 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf27 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf28 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf29 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf3 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf34 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf4 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf40 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf5 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf6 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf7 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf8 | PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf9;
 
 /**
  * 
@@ -2846,14 +2846,14 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30CriterionEnum;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args}
+     * @type {Array<Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInner>>}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30
      */
-    'args': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args;
+    'args': Array<Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInner>>;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30CriterionEnum = {
-    CheckIntentMessage: 'checkIntentMessage'
+    CheckIntentTypedDataMessage: 'checkIntentTypedDataMessage'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30CriterionEnum];
@@ -2861,27 +2861,27 @@ export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30CriterionEnum = typ
 /**
  * 
  * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInner
  */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args {
-    /**
-     * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsOperator}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args
-     */
-    'operator': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsOperator;
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInner {
     /**
      * 
      * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInner
      */
-    'value': string;
+    'key': string;
+    /**
+     * 
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInnerValue}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInner
+     */
+    'value': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInnerValue;
 }
 /**
- * @type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsOperator
+ * @type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInnerValue
  * @export
  */
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsOperator = string;
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30ArgsInnerInnerValue = number | string;
 
 /**
  * 
@@ -2897,17 +2897,42 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31CriterionEnum;
     /**
      * 
-     * @type {Array<string>}
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31
      */
-    'args': Array<string>;
+    'args': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31CriterionEnum = {
-    CheckIntentPayload: 'checkIntentPayload'
+    CheckIntentMessage: 'checkIntentMessage'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31CriterionEnum];
+
+/**
+ * 
+ * @export
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args
+ */
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args {
+    /**
+     * 
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31ArgsOperator}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args
+     */
+    'operator': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31ArgsOperator;
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args
+     */
+    'value': string;
+}
+/**
+ * @type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31ArgsOperator
+ * @export
+ */
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31ArgsOperator = string;
 
 /**
  * 
@@ -2923,48 +2948,17 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32CriterionEnum;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32Args}
+     * @type {Array<string>}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32
      */
-    'args': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32Args;
+    'args': Array<string>;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32CriterionEnum = {
-    CheckPermitDeadline: 'checkPermitDeadline'
+    CheckIntentPayload: 'checkIntentPayload'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32CriterionEnum];
-
-/**
- * 
- * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32Args
- */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32Args {
-    /**
-     * 
-     * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32Args
-     */
-    'operator': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32ArgsOperatorEnum;
-    /**
-     * 
-     * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32Args
-     */
-    'value': string;
-}
-
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32ArgsOperatorEnum = {
-    Gt: 'gt',
-    Lt: 'lt',
-    Gte: 'gte',
-    Lte: 'lte',
-    Eq: 'eq',
-    Ne: 'ne'
-} as const;
-
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32ArgsOperatorEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32ArgsOperatorEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32ArgsOperatorEnum];
 
 /**
  * 
@@ -2980,17 +2974,48 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33CriterionEnum;
     /**
      * 
-     * @type {Array<any>}
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33Args}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33
      */
-    'args': Array<any>;
+    'args': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33Args;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33CriterionEnum = {
-    CheckEntryPointId: 'checkEntryPointId'
+    CheckPermitDeadline: 'checkPermitDeadline'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33CriterionEnum];
+
+/**
+ * 
+ * @export
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33Args
+ */
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33Args {
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33Args
+     */
+    'operator': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33ArgsOperatorEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33Args
+     */
+    'value': string;
+}
+
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33ArgsOperatorEnum = {
+    Gt: 'gt',
+    Lt: 'lt',
+    Gte: 'gte',
+    Lte: 'lte',
+    Eq: 'eq',
+    Ne: 'ne'
+} as const;
+
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33ArgsOperatorEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33ArgsOperatorEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33ArgsOperatorEnum];
 
 /**
  * 
@@ -3013,7 +3038,7 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf34 {
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf34CriterionEnum = {
-    CheckEntryPointAddress: 'checkEntryPointAddress'
+    CheckEntryPointId: 'checkEntryPointId'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf34CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf34CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf34CriterionEnum];
@@ -3032,23 +3057,17 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35CriterionEnum;
     /**
      * 
-     * @type {Array<string>}
+     * @type {Array<any>}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35
      */
-    'args': Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35ArgsEnum>;
+    'args': Array<any>;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35CriterionEnum = {
-    CheckEntryPointAccountType: 'checkEntryPointAccountType'
+    CheckEntryPointAddress: 'checkEntryPointAddress'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35CriterionEnum];
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35ArgsEnum = {
-    Eoa: 'eoa',
-    _4337: '4337'
-} as const;
-
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35ArgsEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35ArgsEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf35ArgsEnum];
 
 /**
  * 
@@ -3067,14 +3086,20 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36 {
      * @type {Array<string>}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36
      */
-    'args': Array<string>;
+    'args': Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36ArgsEnum>;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36CriterionEnum = {
-    CheckEntryPointClassification: 'checkEntryPointClassification'
+    CheckEntryPointAccountType: 'checkEntryPointAccountType'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36CriterionEnum];
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36ArgsEnum = {
+    Eoa: 'eoa',
+    _4337: '4337'
+} as const;
+
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36ArgsEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36ArgsEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf36ArgsEnum];
 
 /**
  * 
@@ -3090,14 +3115,14 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37CriterionEnum;
     /**
      * 
-     * @type {Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner>}
+     * @type {Array<string>}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37
      */
-    'args': Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner>;
+    'args': Array<string>;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37CriterionEnum = {
-    CheckUserOperationIntents: 'checkUserOperationIntents'
+    CheckEntryPointClassification: 'checkEntryPointClassification'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37CriterionEnum];
@@ -3105,102 +3130,128 @@ export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37CriterionEnum = typ
 /**
  * 
  * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38
  */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner {
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38 {
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38
+     */
+    'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum;
+    /**
+     * 
+     * @type {Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38
+     */
+    'args': Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner>;
+}
+
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum = {
+    CheckUserOperationIntents: 'checkUserOperationIntents'
+} as const;
+
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum];
+
+/**
+ * 
+ * @export
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
+ */
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner {
     /**
      * 
      * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
-    'type'?: Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTypeEnum>;
+    'type'?: Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTypeEnum>;
     /**
      * 
      * @type {Array<any>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
     'contract'?: Array<any>;
     /**
      * 
      * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
     'token'?: Array<string>;
     /**
      * 
      * @type {Array<any>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
     'spender'?: Array<any>;
     /**
      * 
      * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
     'chainId'?: Array<string>;
     /**
      * 
      * @type {Array<any>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
     'hexSignature'?: Array<any>;
     /**
      * 
      * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
-    'algorithm'?: Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerAlgorithmEnum>;
+    'algorithm'?: Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerAlgorithmEnum>;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
-    'source'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource;
+    'source'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
-    'destination'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource;
+    'destination'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTransfers}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTransfers}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
-    'transfers'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTransfers;
+    'transfers'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTransfers;
     /**
      * 
      * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf19Args}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
     'amount'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf19Args;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
-    'message'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args;
+    'message'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
-    'payload'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf30Args;
+    'payload'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf31Args;
     /**
      * 
      * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf29Args}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
     'domain'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf29Args;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32Args}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInner
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33Args}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInner
      */
-    'deadline'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf32Args;
+    'deadline'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf33Args;
 }
 
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTypeEnum = {
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTypeEnum = {
     TransferNative: 'transferNative',
     TransferErc20: 'transferErc20',
     TransferErc721: 'transferErc721',
@@ -3220,99 +3271,73 @@ export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTypeEnum 
     UserOperation: 'userOperation'
 } as const;
 
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTypeEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTypeEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTypeEnum];
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerAlgorithmEnum = {
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTypeEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTypeEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTypeEnum];
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerAlgorithmEnum = {
     Es256K: 'ES256K',
     Es256: 'ES256',
     Rs256: 'RS256'
 } as const;
 
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerAlgorithmEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerAlgorithmEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerAlgorithmEnum];
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerAlgorithmEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerAlgorithmEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerAlgorithmEnum];
 
 /**
  * 
  * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource
  */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource {
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource {
     /**
      * 
      * @type {Array<any>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource
      */
     'id'?: Array<any>;
     /**
      * 
      * @type {Array<any>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource
      */
     'address'?: Array<any>;
     /**
      * 
      * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource
      */
-    'accountType'?: Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSourceAccountTypeEnum>;
+    'accountType'?: Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSourceAccountTypeEnum>;
     /**
      * 
      * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSource
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSource
      */
     'classification'?: Array<string>;
 }
 
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSourceAccountTypeEnum = {
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSourceAccountTypeEnum = {
     Eoa: 'eoa',
     _4337: '4337'
 } as const;
 
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSourceAccountTypeEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSourceAccountTypeEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerSourceAccountTypeEnum];
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSourceAccountTypeEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSourceAccountTypeEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerSourceAccountTypeEnum];
 
 /**
  * 
  * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTransfers
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTransfers
  */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTransfers {
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTransfers {
     /**
      * 
      * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTransfers
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTransfers
      */
     'tokens'?: Array<string>;
     /**
      * 
      * @type {Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf27ArgsInner>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf37ArgsInnerTransfers
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38ArgsInnerTransfers
      */
     'amounts'?: Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf27ArgsInner>;
 }
-/**
- * 
- * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38
- */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38 {
-    /**
-     * 
-     * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38
-     */
-    'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum;
-    /**
-     * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf19Args}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38
-     */
-    'args': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf19Args;
-}
-
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum = {
-    CheckGasFeeAmount: 'checkGasFeeAmount'
-} as const;
-
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf38CriterionEnum];
-
 /**
  * 
  * @export
@@ -3327,14 +3352,14 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39CriterionEnum;
     /**
      * 
-     * @type {any}
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf19Args}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39
      */
-    'args': any;
+    'args': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf19Args;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39CriterionEnum = {
-    CheckNonceNotExists: 'checkNonceNotExists'
+    CheckGasFeeAmount: 'checkGasFeeAmount'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf39CriterionEnum];
@@ -3394,7 +3419,7 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf40 {
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf40CriterionEnum = {
-    CheckNonceExists: 'checkNonceExists'
+    CheckNonceNotExists: 'checkNonceNotExists'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf40CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf40CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf40CriterionEnum];
@@ -3413,57 +3438,17 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41CriterionEnum;
     /**
      * 
-     * @type {Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInner>}
+     * @type {any}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41
      */
-    'args': Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInner>;
+    'args': any;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41CriterionEnum = {
-    CheckApprovals: 'checkApprovals'
+    CheckNonceExists: 'checkNonceExists'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41CriterionEnum];
-
-/**
- * 
- * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInner
- */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInner {
-    /**
-     * 
-     * @type {number}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInner
-     */
-    'approvalCount': number;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInner
-     */
-    'countPrincipal': boolean;
-    /**
-     * 
-     * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInner
-     */
-    'approvalEntityType': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInnerApprovalEntityTypeEnum;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInner
-     */
-    'entityIds': Array<string>;
-}
-
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInnerApprovalEntityTypeEnum = {
-    User: 'Narval::User',
-    UserRole: 'Narval::UserRole',
-    UserGroup: 'Narval::UserGroup'
-} as const;
-
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInnerApprovalEntityTypeEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInnerApprovalEntityTypeEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf41ArgsInnerApprovalEntityTypeEnum];
 
 /**
  * 
@@ -3479,14 +3464,14 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42 {
     'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42CriterionEnum;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args}
+     * @type {Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInner>}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42
      */
-    'args': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args;
+    'args': Array<PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInner>;
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42CriterionEnum = {
-    CheckSpendingLimit: 'checkSpendingLimit'
+    CheckApprovals: 'checkApprovals'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42CriterionEnum];
@@ -3494,164 +3479,42 @@ export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42CriterionEnum = typ
 /**
  * 
  * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInner
  */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args {
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInner {
     /**
      * 
-     * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args
+     * @type {number}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInner
      */
-    'limit': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args
-     */
-    'operator': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsOperatorEnum;
-    /**
-     * 
-     * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args
-     */
-    'currency'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsCurrencyEnum;
-    /**
-     * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args
-     */
-    'timeWindow'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow;
-    /**
-     * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42Args
-     */
-    'filters'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters;
-}
-
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsOperatorEnum = {
-    Gt: 'gt',
-    Lt: 'lt',
-    Gte: 'gte',
-    Lte: 'lte',
-    Eq: 'eq',
-    Ne: 'ne'
-} as const;
-
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsOperatorEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsOperatorEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsOperatorEnum];
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsCurrencyEnum = {
-    Usd: 'fiat:usd',
-    Eur: 'fiat:eur'
-} as const;
-
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsCurrencyEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsCurrencyEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsCurrencyEnum];
-
-/**
- * 
- * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
- */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters {
+    'approvalCount': number;
     /**
      * 
      * @type {boolean}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInner
      */
-    'perPrincipal'?: boolean;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
-     */
-    'tokens'?: Array<string>;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
-     */
-    'users'?: Array<string>;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
-     */
-    'resources'?: Array<string>;
-    /**
-     * 
-     * @type {Array<any>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
-     */
-    'destinations'?: Array<any>;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
-     */
-    'chains'?: Array<string>;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
-     */
-    'userGroups'?: Array<string>;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters
-     */
-    'accountGroups'?: Array<string>;
-}
-/**
- * 
- * @export
- * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow
- */
-export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow {
+    'countPrincipal': boolean;
     /**
      * 
      * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInner
      */
-    'type'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowTypeEnum;
+    'approvalEntityType': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInnerApprovalEntityTypeEnum;
     /**
      * 
-     * @type {string}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow
+     * @type {Array<string>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInner
      */
-    'period'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowPeriodEnum;
-    /**
-     * 
-     * @type {number}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow
-     */
-    'value'?: number;
-    /**
-     * 
-     * @type {number}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow
-     */
-    'startDate'?: number;
-    /**
-     * 
-     * @type {number}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow
-     */
-    'endDate'?: number;
+    'entityIds': Array<string>;
 }
 
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowTypeEnum = {
-    Rolling: 'rolling',
-    Fixed: 'fixed'
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInnerApprovalEntityTypeEnum = {
+    User: 'Narval::User',
+    UserRole: 'Narval::UserRole',
+    UserGroup: 'Narval::UserGroup'
 } as const;
 
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowTypeEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowTypeEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowTypeEnum];
-export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowPeriodEnum = {
-    _1d: '1d',
-    _1m: '1m',
-    _1y: '1y'
-} as const;
-
-export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowPeriodEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowPeriodEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindowPeriodEnum];
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInnerApprovalEntityTypeEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInnerApprovalEntityTypeEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsInnerApprovalEntityTypeEnum];
 
 /**
  * 
@@ -3674,7 +3537,7 @@ export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43 {
 }
 
 export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43CriterionEnum = {
-    CheckRateLimit: 'checkRateLimit'
+    CheckSpendingLimit: 'checkSpendingLimit'
 } as const;
 
 export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43CriterionEnum];
@@ -3687,22 +3550,210 @@ export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43CriterionEnum = typ
 export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43Args {
     /**
      * 
-     * @type {number}
+     * @type {string}
      * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43Args
+     */
+    'limit': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43Args
+     */
+    'operator': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsOperatorEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43Args
+     */
+    'currency'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsCurrencyEnum;
+    /**
+     * 
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43Args
+     */
+    'timeWindow'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow;
+    /**
+     * 
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43Args
+     */
+    'filters'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters;
+}
+
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsOperatorEnum = {
+    Gt: 'gt',
+    Lt: 'lt',
+    Gte: 'gte',
+    Lte: 'lte',
+    Eq: 'eq',
+    Ne: 'ne'
+} as const;
+
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsOperatorEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsOperatorEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsOperatorEnum];
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsCurrencyEnum = {
+    Usd: 'fiat:usd',
+    Eur: 'fiat:eur'
+} as const;
+
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsCurrencyEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsCurrencyEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsCurrencyEnum];
+
+/**
+ * 
+ * @export
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+ */
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters {
+    /**
+     * 
+     * @type {boolean}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+     */
+    'perPrincipal'?: boolean;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+     */
+    'tokens'?: Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+     */
+    'users'?: Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+     */
+    'resources'?: Array<string>;
+    /**
+     * 
+     * @type {Array<any>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+     */
+    'destinations'?: Array<any>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+     */
+    'chains'?: Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+     */
+    'userGroups'?: Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters
+     */
+    'accountGroups'?: Array<string>;
+}
+/**
+ * 
+ * @export
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow
+ */
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow {
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow
+     */
+    'type'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowTypeEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow
+     */
+    'period'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowPeriodEnum;
+    /**
+     * 
+     * @type {number}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow
+     */
+    'value'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow
+     */
+    'startDate'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow
+     */
+    'endDate'?: number;
+}
+
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowTypeEnum = {
+    Rolling: 'rolling',
+    Fixed: 'fixed'
+} as const;
+
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowTypeEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowTypeEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowTypeEnum];
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowPeriodEnum = {
+    _1d: '1d',
+    _1m: '1m',
+    _1y: '1y'
+} as const;
+
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowPeriodEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowPeriodEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindowPeriodEnum];
+
+/**
+ * 
+ * @export
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44
+ */
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44 {
+    /**
+     * 
+     * @type {string}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44
+     */
+    'criterion': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44CriterionEnum;
+    /**
+     * 
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44Args}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44
+     */
+    'args': PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44Args;
+}
+
+export const PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44CriterionEnum = {
+    CheckRateLimit: 'checkRateLimit'
+} as const;
+
+export type PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44CriterionEnum = typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44CriterionEnum[keyof typeof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44CriterionEnum];
+
+/**
+ * 
+ * @export
+ * @interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44Args
+ */
+export interface PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44Args {
+    /**
+     * 
+     * @type {number}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44Args
      */
     'limit': number;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43Args
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44Args
      */
-    'timeWindow'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsTimeWindow;
+    'timeWindow'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsTimeWindow;
     /**
      * 
-     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters}
-     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43Args
+     * @type {PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters}
+     * @memberof PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf44Args
      */
-    'filters'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf42ArgsFilters;
+    'filters'?: PolicyDataStoreDtoPolicyDataInnerWhenInnerOneOf43ArgsFilters;
 }
 /**
  * 

--- a/packages/policy-engine-shared/src/lib/schema/policy.schema.ts
+++ b/packages/policy-engine-shared/src/lib/schema/policy.schema.ts
@@ -76,6 +76,7 @@ export const criterionSchema = z.nativeEnum({
   CHECK_INTENT_PAYLOAD: 'checkIntentPayload',
   CHECK_INTENT_ALGORITHM: 'checkIntentAlgorithm',
   CHECK_INTENT_DOMAIN: 'checkIntentDomain',
+  CHECK_INTENT_TYPED_DATA_MESSAGE: 'checkIntentTypedDataMessage',
   // Intent Token Transfers
   CHECK_ERC1155_TOKEN_ID: 'checkErc1155TokenId',
   CHECK_ERC1155_TRANSFERS: 'checkErc1155Transfers',
@@ -133,6 +134,11 @@ export const signTypedDataDomainConditionSchema = z.object({
   name: z.array(z.string()).min(1).optional(),
   verifyingContract: z.array(addressSchema).min(1).optional()
 })
+
+export const signTypedDataMessageConditionSchema = z.array(z.object({
+  key: z.string().min(1),
+  value: z.union([z.string().min(1), z.number()])
+}))
 
 export const permitDeadlineConditionSchema = z.object({
   operator: z.nativeEnum(ValueOperators),
@@ -379,6 +385,11 @@ export const intentDomainCriterionSchema = z.object({
   args: signTypedDataDomainConditionSchema
 })
 
+export const intentTypedDataMessageCriterionSchema = z.object({
+  criterion: z.literal(criterionSchema.enum.CHECK_INTENT_TYPED_DATA_MESSAGE),
+  args: z.array(signTypedDataMessageConditionSchema),
+})
+
 // Intent Permit Deadline
 export const permitDeadlineCriterionSchema = z.object({
   criterion: z.literal(criterionSchema.enum.CHECK_PERMIT_DEADLINE),
@@ -486,6 +497,7 @@ export const policyCriterionSchema = z.discriminatedUnion('criterion', [
   // Intent Sign Message
   intentAlgorithmCriterionSchema,
   intentDomainCriterionSchema,
+  intentTypedDataMessageCriterionSchema,
   intentMessageCriterionSchema,
   intentPayloadCriterionSchema,
   // Intent Permit Deadline

--- a/packages/policy-engine-shared/src/lib/schema/policy.schema.ts
+++ b/packages/policy-engine-shared/src/lib/schema/policy.schema.ts
@@ -135,10 +135,12 @@ export const signTypedDataDomainConditionSchema = z.object({
   verifyingContract: z.array(addressSchema).min(1).optional()
 })
 
-export const signTypedDataMessageConditionSchema = z.array(z.object({
-  key: z.string().min(1),
-  value: z.union([z.string().min(1), z.number()])
-}))
+export const signTypedDataMessageConditionSchema = z.array(
+  z.object({
+    key: z.string().min(1),
+    value: z.union([z.string().min(1), z.number()])
+  })
+)
 
 export const permitDeadlineConditionSchema = z.object({
   operator: z.nativeEnum(ValueOperators),
@@ -387,7 +389,7 @@ export const intentDomainCriterionSchema = z.object({
 
 export const intentTypedDataMessageCriterionSchema = z.object({
   criterion: z.literal(criterionSchema.enum.CHECK_INTENT_TYPED_DATA_MESSAGE),
-  args: z.array(signTypedDataMessageConditionSchema),
+  args: z.array(signTypedDataMessageConditionSchema)
 })
 
 // Intent Permit Deadline

--- a/packages/transaction-request-intent/src/lib/__test__/unit/decoders.spec.ts
+++ b/packages/transaction-request-intent/src/lib/__test__/unit/decoders.spec.ts
@@ -316,15 +316,30 @@ describe('decode', () => {
       })
       expect(decoded).toEqual({
         type: Intents.SIGN_TYPED_DATA,
-        domain: {
-          version: '0.1.0',
-          name: 'Unicorn Milk Token',
-          chainId: 137,
-          verifyingContract: '0x64060aB139Feaae7f06Ca4E63189D86aDEb51691'
-        },
-        message: {
-          do: 'doingStuff(address stuff)',
-          stuff: '0x1234567890123456789012345678901234567890'
+        typedData: {
+          types: {
+            EIP712Domain: [
+              { name: 'name', type: 'string' },
+              { name: 'version', type: 'string' },
+              { name: 'chainId', type: 'uint256' },
+              { name: 'verifyingContract', type: 'address' }
+            ],
+            DoStuff: [
+              { name: 'do', type: 'function' },
+              { name: 'stuff', type: 'address' }
+            ]
+          },
+          primaryType: 'DoStuff',
+          domain: {
+            name: 'Unicorn Milk Token',
+            version: '0.1.0',
+            chainId: 137,
+            verifyingContract: '0x64060aB139Feaae7f06Ca4E63189D86aDEb51691'
+          },
+          message: {
+            do: 'doingStuff(address stuff)',
+            stuff: '0x1234567890123456789012345678901234567890'
+          }
         }
       })
     })

--- a/packages/transaction-request-intent/src/lib/__test__/unit/decoders.spec.ts
+++ b/packages/transaction-request-intent/src/lib/__test__/unit/decoders.spec.ts
@@ -321,6 +321,10 @@ describe('decode', () => {
           name: 'Unicorn Milk Token',
           chainId: 137,
           verifyingContract: '0x64060aB139Feaae7f06Ca4E63189D86aDEb51691'
+        },
+        message: {
+          do: 'doingStuff(address stuff)',
+          stuff: '0x1234567890123456789012345678901234567890'
         }
       })
     })

--- a/packages/transaction-request-intent/src/lib/intent.types.ts
+++ b/packages/transaction-request-intent/src/lib/intent.types.ts
@@ -1,4 +1,4 @@
-import { AssetId, ChainAccountId, Eip712Domain, Hex } from '@narval/policy-engine-shared'
+import { AssetId, ChainAccountId, Eip712TypedData, Hex } from '@narval/policy-engine-shared'
 import { Alg } from '@narval/signature'
 import { Intents } from './domain'
 
@@ -60,8 +60,7 @@ export type SignRaw = {
 
 export type SignTypedData = {
   type: Intents.SIGN_TYPED_DATA
-  domain?: Eip712Domain
-  message?: Record<string, unknown>
+  typedData: Eip712TypedData
 }
 
 export type DeployContract = {

--- a/packages/transaction-request-intent/src/lib/intent.types.ts
+++ b/packages/transaction-request-intent/src/lib/intent.types.ts
@@ -61,6 +61,7 @@ export type SignRaw = {
 export type SignTypedData = {
   type: Intents.SIGN_TYPED_DATA
   domain?: Eip712Domain
+  message?: Record<string, unknown>
 }
 
 export type DeployContract = {

--- a/packages/transaction-request-intent/src/lib/utils.ts
+++ b/packages/transaction-request-intent/src/lib/utils.ts
@@ -175,8 +175,7 @@ export const buildTransactionRegistry = (input: TransactionRegistryInput): Trans
 
 export const decodeTypedData = (typedData: Eip712TypedData): SignTypedData => ({
   type: Intents.SIGN_TYPED_DATA,
-  domain: typedData.domain,
-  message: typedData.message
+  typedData,
 })
 
 export const decodeMessage = (message: MessageInput): SignMessage => {

--- a/packages/transaction-request-intent/src/lib/utils.ts
+++ b/packages/transaction-request-intent/src/lib/utils.ts
@@ -175,7 +175,7 @@ export const buildTransactionRegistry = (input: TransactionRegistryInput): Trans
 
 export const decodeTypedData = (typedData: Eip712TypedData): SignTypedData => ({
   type: Intents.SIGN_TYPED_DATA,
-  typedData,
+  typedData
 })
 
 export const decodeMessage = (message: MessageInput): SignMessage => {

--- a/packages/transaction-request-intent/src/lib/utils.ts
+++ b/packages/transaction-request-intent/src/lib/utils.ts
@@ -175,7 +175,8 @@ export const buildTransactionRegistry = (input: TransactionRegistryInput): Trans
 
 export const decodeTypedData = (typedData: Eip712TypedData): SignTypedData => ({
   type: Intents.SIGN_TYPED_DATA,
-  domain: typedData.domain
+  domain: typedData.domain,
+  message: typedData.message
 })
 
 export const decodeMessage = (message: MessageInput): SignMessage => {


### PR DESCRIPTION
- Add support for an equality check over key-value fields in typedData.message
- Rule behaves like so:
```
[
  [{key, value} AND {key, value}...] in typedData.message 
  OR [{key, value} AND {key, value}...] in typedData.message
  ...
]