### PR TITLE
separating type & const+type exports to fix isolatedModule build challenge

### DIFF
--- a/packages/armory-sdk/src/index.ts
+++ b/packages/armory-sdk/src/index.ts
@@ -25,28 +25,31 @@ export {
   signJwt
 } from '@narval/signature'
 
-export type {
+export {
   AccessToken,
-  AccountEntity,
   AccountType,
   Action,
-  Address,
   CreateAuthorizationRequest,
   Criterion,
   Decision,
   Eip712TypedData,
-  Entities,
   EntityType,
-  Hex,
   JwtString,
-  Policy,
-  PolicyCriterion,
   Request,
   Then,
   TransactionRequest,
-  UserEntity,
   UserRole,
   ValueOperators
+} from '@narval/policy-engine-shared'
+
+export type {
+  AccountEntity,
+  Address,
+  Entities,
+  Hex,
+  Policy,
+  PolicyCriterion,
+  UserEntity
 } from '@narval/policy-engine-shared'
 
 export { EntityUtil, getAddress, toHex } from '@narval/policy-engine-shared'


### PR DESCRIPTION
You can't re-export Types & Const+Types in the same re-export statement.
I've moved the ones that are only `type` exports into a separate statement, and exported the ones that have const & type defs together.
This should fix the nextjs builds w/ isolatedModules, and the import/const usage issues.