### PR TITLE
Bugfix with chain lookup

### DIFF
--- a/apps/armory/src/data-feed/core/service/__test__/unit/price-feed.service.spec.ts
+++ b/apps/armory/src/data-feed/core/service/__test__/unit/price-feed.service.spec.ts
@@ -80,13 +80,14 @@ describe(PriceFeedService.name, () => {
       })
     })
 
-    it('calls price service', async () => {
-      await service.getFeed(authzRequest)
+    // 15-08-2024 @mattschoch - skipping because price feed is currently disabled
+    // it('calls price service', async () => {
+    //   await service.getFeed(authzRequest)
 
-      expect(priceServiceMock.getPrices).toHaveBeenCalledWith({
-        from: [POLYGON.coin.id],
-        to: [FIAT_ID_USD]
-      })
-    })
+    //   expect(priceServiceMock.getPrices).toHaveBeenCalledWith({
+    //     from: [POLYGON.coin.id],
+    //     to: [FIAT_ID_USD]
+    //   })
+    // })
   })
 })

--- a/apps/armory/src/data-feed/core/service/price-feed.service.ts
+++ b/apps/armory/src/data-feed/core/service/price-feed.service.ts
@@ -1,17 +1,13 @@
 import { ConfigService } from '@narval/config-module'
-import { Action, AssetId, AuthorizationRequest, Feed, JwtString } from '@narval/policy-engine-shared'
+import { AssetId, AuthorizationRequest, Feed, JwtString } from '@narval/policy-engine-shared'
 import { Alg, Payload, SigningAlg, hash, hexToBase64Url, privateKeyToJwk, signJwt } from '@narval/signature'
-import { InputType, Intents, safeDecode } from '@narval/transaction-request-intent'
 import { Injectable } from '@nestjs/common'
-import { uniq } from 'lodash/fp'
 import { privateKeyToAccount } from 'viem/accounts'
 import { Config } from '../../../armory.config'
 import { FIAT_ID_USD } from '../../../armory.constant'
 import { PriceService } from '../../../price/core/service/price.service'
-import { getChain } from '../../../shared/core/lib/chains.lib'
 import { Prices } from '../../../shared/core/type/price.type'
 import { DataFeed } from '../type/data-feed.type'
-
 @Injectable()
 export class PriceFeedService implements DataFeed<Prices> {
   static SOURCE_ID = 'armory/price-feed'
@@ -62,6 +58,7 @@ export class PriceFeedService implements DataFeed<Prices> {
     // TODO (@wcalderipe, 01/02/2024): De-risk the price values by taking a
     // median of multiple sources.
     const prices = await this.priceService.getPrices({
+      // see comment in getAssetIds. This only returns the caip19 of the chain, not the caip19 of an erc20 token
       from: this.getAssetIds(input),
       to: [FIAT_ID_USD]
     })
@@ -75,27 +72,29 @@ export class PriceFeedService implements DataFeed<Prices> {
   }
 
   private getAssetIds(authzRequest: AuthorizationRequest): AssetId[] {
-    if (authzRequest.request.action === Action.SIGN_TRANSACTION) {
-      const result = safeDecode({
-        input: {
-          type: InputType.TRANSACTION_REQUEST,
-          txRequest: authzRequest.request.transactionRequest
-        }
-      })
-
-      const chain = getChain(authzRequest.request.transactionRequest.chainId)
-
-      if (result.success) {
-        const { intent } = result
-
-        if (intent.type === Intents.TRANSFER_NATIVE) {
-          return uniq([chain.coin.id, intent.token])
-        }
-      }
-
-      return [chain.coin.id]
-    }
-
     return []
+  // Problem: this always returns the coinId of the chain, not the caip19 of an erc20 token. Even if its not a transfer_native intent
+  //   if (authzRequest.request.action === Action.SIGN_TRANSACTION) {
+  //     const result = safeDecode({
+  //       input: {
+  //         type: InputType.TRANSACTION_REQUEST,
+  //         txRequest: authzRequest.request.transactionRequest
+  //       }
+  //     })
+
+  //     const chain = getChain(authzRequest.request.transactionRequest.chainId)
+
+  //     if (result.success) {
+  //       const { intent } = result
+
+  //       if (intent.type === Intents.TRANSFER_NATIVE) {
+  //         return uniq([chain.coin.id, intent.token])
+  //       }
+  //     }
+
+  //     return [chain.coin.id]
+  //   }
+
+  //   return []
   }
 }

--- a/apps/armory/src/data-feed/core/service/price-feed.service.ts
+++ b/apps/armory/src/data-feed/core/service/price-feed.service.ts
@@ -73,28 +73,28 @@ export class PriceFeedService implements DataFeed<Prices> {
 
   private getAssetIds(authzRequest: AuthorizationRequest): AssetId[] {
     return []
-  // Problem: this always returns the coinId of the chain, not the caip19 of an erc20 token. Even if its not a transfer_native intent
-  //   if (authzRequest.request.action === Action.SIGN_TRANSACTION) {
-  //     const result = safeDecode({
-  //       input: {
-  //         type: InputType.TRANSACTION_REQUEST,
-  //         txRequest: authzRequest.request.transactionRequest
-  //       }
-  //     })
+    // Problem: this always returns the coinId of the chain, not the caip19 of an erc20 token. Even if its not a transfer_native intent
+    //   if (authzRequest.request.action === Action.SIGN_TRANSACTION) {
+    //     const result = safeDecode({
+    //       input: {
+    //         type: InputType.TRANSACTION_REQUEST,
+    //         txRequest: authzRequest.request.transactionRequest
+    //       }
+    //     })
 
-  //     const chain = getChain(authzRequest.request.transactionRequest.chainId)
+    //     const chain = getChain(authzRequest.request.transactionRequest.chainId)
 
-  //     if (result.success) {
-  //       const { intent } = result
+    //     if (result.success) {
+    //       const { intent } = result
 
-  //       if (intent.type === Intents.TRANSFER_NATIVE) {
-  //         return uniq([chain.coin.id, intent.token])
-  //       }
-  //     }
+    //       if (intent.type === Intents.TRANSFER_NATIVE) {
+    //         return uniq([chain.coin.id, intent.token])
+    //       }
+    //     }
 
-  //     return [chain.coin.id]
-  //   }
+    //     return [chain.coin.id]
+    //   }
 
-  //   return []
+    //   return []
   }
 }

--- a/apps/policy-engine/src/engine/__test__/e2e/evaluation.spec.ts
+++ b/apps/policy-engine/src/engine/__test__/e2e/evaluation.spec.ts
@@ -253,7 +253,7 @@ describe('Evaluation', () => {
                     amount: '1',
                     from: `eip155:${sepolia.id}:${FIXTURE.VIEM_ACCOUNT.Alice.address.toLowerCase()}`,
                     to: `eip155:${sepolia.id}:${FIXTURE.VIEM_ACCOUNT.Bob.address.toLowerCase()}`,
-                    token: `eip155:${sepolia.id}/slip44:966`,
+                    token: `eip155:${sepolia.id}/slip44:60`,
                     type: 'transferNative'
                   }
                 ]

--- a/packages/transaction-request-intent/src/lib/domain.ts
+++ b/packages/transaction-request-intent/src/lib/domain.ts
@@ -155,12 +155,22 @@ export type AssetTypeAndUnknown = AssetType | Misc.UNKNOWN
 export enum SupportedChains {
   ETHEREUM = 1,
   POLYGON = 137,
-  OPTIMISM = 10
+  OPTIMISM = 10,
+  BNB = 56,
+  FTM = 250,
+  ARBITRUM = 42161,
+  AVALANCHE = 43114,
+  CELO = 42220,
 }
 
 export enum Slip44SupportedAddresses {
   ETH = 60,
-  MATIC = 966
+  MATIC = 966,
+  BNB = 714,
+  FTM = 1007,
+  ARBITRUM = 9001,
+  AVALANCHE = 9000,
+  CELO = 52752,
 }
 export const PERMIT2_ADDRESS = '0x000000000022d473030f116ddee9f6b43ac78ba3'
 export const NULL_METHOD_ID = '0x00000000'

--- a/packages/transaction-request-intent/src/lib/utils.ts
+++ b/packages/transaction-request-intent/src/lib/utils.ts
@@ -330,7 +330,32 @@ export const checkCancelTransaction = (input: NativeTransferInput): Intents => {
 }
 
 export const nativeCaip19 = (chainId: number): AssetId => {
-  const coinType = chainId === SupportedChains.ETHEREUM ? Slip44SupportedAddresses.ETH : Slip44SupportedAddresses.MATIC
+  let coinType;
+  switch (chainId) {
+    case SupportedChains.CELO:
+      coinType = Slip44SupportedAddresses.CELO
+      break
+    case SupportedChains.BNB:
+      coinType = Slip44SupportedAddresses.BNB
+      break
+    case SupportedChains.AVALANCHE:
+      coinType = Slip44SupportedAddresses.AVALANCHE
+      break
+    case SupportedChains.ARBITRUM:
+      coinType = Slip44SupportedAddresses.ARBITRUM
+      break
+    case SupportedChains.FTM:
+      coinType = Slip44SupportedAddresses.FTM
+      break
+    case SupportedChains.POLYGON:
+      coinType = Slip44SupportedAddresses.MATIC
+      break
+    case SupportedChains.OPTIMISM:
+      coinType = Slip44SupportedAddresses.ETH
+      break
+    default:
+      coinType = Slip44SupportedAddresses.ETH
+  }
   return toAssetId({
     chainId,
     assetType: AssetType.SLIP44,


### PR DESCRIPTION
This PR stop gathering 'AssetIds' for price feed.
The subsequent call to `getPrices` method is hardcoded to return an empty object. So the solution here is to also force the return of an empty array in `getAssetIds` method instead of trying to build a list of assetsIds.

This is the only place where `chains` constant seems to be used. So maybe we can deprecate it at the scope of this PR, and find another solution to gather prices later