### PR TITLE
Making base docker-compose run simple signer; cleaning up .env.defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,7 @@ docker/up:
 docker/stop:
 	docker-compose stop
 
-# Starts the Armory stack in Docker containers.
-# Useful when you want to use MPC as the signing protocol.
+# Starts the whole Armory stack in Docker containers.
 docker/stack/up:
 	docker-compose up --detach
 
@@ -104,11 +103,19 @@ docker/stack/stop:
 	docker-compose stop
 
 docker/stack/build:
-	docker build \
+	docker buildx build \
+		--platform linux/amd64 \
 		--file local.dockerfile \
 		--tag armory/local:latest \
 		. --load
 
+# Starts the whole Armory stack for MPC in Docker containers.
+# Requires the mpc nodes to be configured seprately.
+docker/mpc/up:
+	docker-compose -f docker-compose.mpc.yml up --detach
+
+docker/mpc/stop:
+	docker-compose -f docker-compose.mpc.yml stop
 
 # === Git ===
 git/tag/push:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ auth system, able to be deployed in a variety of secure configurations.
 
 ![Armory Stack diagram](./resources/armory-stack.png)
 
+## Requirements
+
+Node.js 21+
+
+Docker
+
+OPA CLI (if not running in Docker) [link](https://www.openpolicyagent.org/docs/latest/#running-opa)
+
 ## Getting started
 
 To setup the project, run the following command:
@@ -42,12 +50,10 @@ make docker/up
 make docker/stop
 ```
 
-Alternatively, you can run the entire stack in Docker containers. This is
-useful when using the MPC as a signing protocol in the Policy Engine.
+Alternatively, you can run the entire development stack in Docker containers.
 
 > [!IMPORTANT]
-> You also need a locally running TSM cluster, which is not included in this
-> repository.
+> This builds a local dev image that mounts your filesystem into the container. Only db schema, dependency, or config changes require re-building. Do not use this build for production.
 
 ```bash
 # Build the application's image.

--- a/apps/armory/.env.default
+++ b/apps/armory/.env.default
@@ -2,13 +2,15 @@ NODE_ENV=development
 
 PORT=3005
 
-APP_UID=local-dev-armory-instance-1
-
 # OPTIONAL: Sets the admin API key instead of generating a new one during the
 # provision.
 #
-# Plain text API key: 2cfa9d09a28f1de9108d18c38f5d5304e6708744c7d7194cbc754aef3455edc7e9270e2f28f052622257
-ADMIN_API_KEY=7d4064073efcfef92d85f274c70e82f980128168e9fb171a613dc7fdaf446b5d
+# Key should be hashed, like this: `echo -n "my-api-key" | openssl dgst -sha256 | awk '{print $2}'`
+# Plain text API key: armory-admin-api-key
+ADMIN_API_KEY=171c50ec62122b8c08362dcf9dce9b016ed615cfc7b90d4bc3fe5b223d967fb2
+
+# APP db connection string
+APP_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/armory?schema=public
 
 # MIGRATOR db credentials. host/port/name should be the same, username&password may be different
 APP_DATABASE_USERNAME=postgres
@@ -17,8 +19,7 @@ APP_DATABASE_HOST=host.docker.internal
 APP_DATABASE_PORT=5432
 APP_DATABASE_NAME=armory
 
-# APP db connection string
-APP_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/armory?schema=public
+APP_UID=local-dev-armory-instance-1
 
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/apps/devtool/.env.development
+++ b/apps/devtool/.env.development
@@ -1,0 +1,6 @@
+NEXT_PUBLIC_AUTH_SERVER_URL=http://localhost:3005
+NEXT_PUBLIC_ENGINE_SERVER_URL=http://localhost:3010
+NEXT_PUBLIC_VAULT_SERVER_URL=http://localhost:3011
+
+NEXT_PUBLIC_LOCAL_DATA_STORE_URL=http://localhost:4200/api/data-store
+NEXT_PUBLIC_MANAGED_DATASTORE_BASE_URL=http://localhost:3005/data

--- a/apps/devtool/src/app/_lib/constants.ts
+++ b/apps/devtool/src/app/_lib/constants.ts
@@ -1,9 +1,11 @@
-export const LOCAL_DATA_STORE_URL = 'http://localhost:4200/api/data-store'
-export const AUTH_SERVER_URL = 'https://auth.armory.narval.xyz'
-export const ENGINE_URL = 'http://localhost:3010'
-export const VAULT_URL = 'https://vault.armory.narval.xyz'
+export const LOCAL_DATA_STORE_URL =
+  process.env.NEXT_PUBLIC_LOCAL_DATA_STORE_URL || 'http://localhost:4200/api/data-store'
+export const AUTH_SERVER_URL = process.env.NEXT_PUBLIC_AUTH_SERVER_URL || 'https://auth.armory.narval.xyz'
+export const ENGINE_URL = process.env.NEXT_PUBLIC_ENGINE_SERVER_URL || 'http://localhost:3010'
+export const VAULT_URL = process.env.NEXT_PUBLIC_VAULT_SERVER_URL || 'https://vault.armory.narval.xyz'
 
-export const MANAGED_DATASTORE_BASE_URL = 'http://localhost:3005/data'
+export const MANAGED_DATASTORE_BASE_URL =
+  process.env.NEXT_PUBLIC_MANAGED_DATASTORE_BASE_URL || 'http://localhost:3005/data'
 
 export const LOCAL_STORAGE_KEYS = {
   // Auth Server

--- a/apps/devtool/src/app/config/_components/engine/EngineConfig.tsx
+++ b/apps/devtool/src/app/config/_components/engine/EngineConfig.tsx
@@ -11,7 +11,7 @@ const EngineConfig = () => {
   return (
     <div className="flex flex-col gap-[48px]">
       <div className="flex items-center">
-        <div className="text-nv-2xl grow">Policy Engine</div>
+        <div className="text-nv-2xl grow">Policy Engine (if not using Auth)</div>
         <AddEngineClientModal />
       </div>
       <div className="flex flex-col gap-6">

--- a/apps/policy-engine/.env.default
+++ b/apps/policy-engine/.env.default
@@ -5,14 +5,14 @@ PORT=3010
 # OPTIONAL: Sets the admin API key instead of generating a new one during the
 # provision.
 #
-# Plain text API key: 9c13888d6dd4a7fb43c9ba8025d9d18d836a2a23f2f3f6ac4d005540fba7be3345ad5e2315e417d6b4a4
-ADMIN_API_KEY=48dfe2b4195245787ed258756e09a37d2a2ac1d1d0fe82c048af8a4e717bc45b
+# Key should be hashed, like this: `echo -n "my-api-key" | openssl dgst -sha256 | awk '{print $2}'`
+# Plain text API key: engine-admin-api-key
+ADMIN_API_KEY=dde1fba05d6b0b1a40f2cd9f480f6dcc37a6980bcff3db54377a46b056dc472c
 
 # APP db connection string
 APP_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/engine?schema=public
 
-# MIGRATOR db credentials. host/port/name should be the same, username&password
-# may be different
+# MIGRATOR db credentials. host/port/name should be the same, username&password may be different
 APP_DATABASE_USERNAME=postgres
 APP_DATABASE_PASSWORD=postgres
 APP_DATABASE_HOST=host.docker.internal
@@ -21,16 +21,21 @@ APP_DATABASE_NAME=engine
 
 APP_UID=local-dev-engine-instance-1
 
-MASTER_PASSWORD=unsafe-local-dev-master-password
-
 RESOURCE_PATH=./apps/policy-engine/src/resource
 
+# awskms or raw
 KEYRING_TYPE=raw
 
-# MASTER_AWS_KMS_ARN=arn:aws:kms:us-east-2:728783560968:key/f6aa3ddb-47c3-4f31-977d-b93205bb23d1
+# If using raw keyring, master password for encrypting data
+MASTER_PASSWORD=unsafe-local-dev-master-password
 
+# If using awskms keyring, provide the ARN of the KMS encryption key instead of a master password
+MASTER_AWS_KMS_ARN=
+
+# simple or mpc
 SIGNING_PROTOCOL=simple
 
+# If mpc, add config params here.
 TSM_URL=
 TSM_API_KEY=
 TSM_PLAYER_COUNT=

--- a/apps/vault/.env.default
+++ b/apps/vault/.env.default
@@ -5,8 +5,9 @@ PORT=3011
 # OPTIONAL: Sets the admin API key instead of generating a new one during the
 # provision.
 #
-# Plain text API key: b8795927715a31131072b3b6490f9705d56895aa2d1f89d9bdd39b1c815cb3dfe71e5f72c6ef174f00ca
-ADMIN_API_KEY=8466917e32fdbb9aa616b486b8d1b4be779df7c12ada869ce32e498cfaa3812e
+# Key should be hashed, like this: `echo -n "my-api-key" | openssl dgst -sha256 | awk '{print $2}'`
+# Plain text API key: vault-admin-api-key
+ADMIN_API_KEY=d4a6b4c1cb71dbdb68a1dd429ad737369f74b9e264b9dfa639258753987caaad
 
 # APP db connection string
 APP_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vault?schema=public
@@ -20,11 +21,14 @@ APP_DATABASE_NAME=vault
 
 APP_UID=local-dev-vault-instance-1
 
-MASTER_PASSWORD=unsafe-local-dev-master-password
-
+# awskms or raw
 KEYRING_TYPE=raw
 
-# MASTER_AWS_KMS_ARN=arn:aws:kms:us-east-2:728783560968:key/f6aa3ddb-47c3-4f31-977d-b93205bb23d1
+# If using raw keyring, master password for encrypting data
+MASTER_PASSWORD=unsafe-local-dev-master-password
+
+# If using awskms keyring, provide the ARN of the KMS encryption key instead of a master password
+MASTER_AWS_KMS_ARN=
 
 # BaseUrl where the Vault is deployed. Will be used to verify jwsd request signatures
 BASE_URL=http://localhost:3011

--- a/docker-compose.mpc.yml
+++ b/docker-compose.mpc.yml
@@ -44,21 +44,12 @@ services:
     networks:
       - armory_stack
     environment:
-      - NODE_ENV=development
       - PORT=3010
-      - APP_UID=local-dev-armory-instance-1
-      - ADMIN_API_KEY=171c50ec62122b8c08362dcf9dce9b016ed615cfc7b90d4bc3fe5b223d967fb2 # armory-admin-api-key
       - APP_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/armory?schema=public
-      - APP_DATABASE_USERNAME=postgres
-      - APP_DATABASE_PASSWORD=postgres
-      - APP_DATABASE_HOST=host.docker.internal
-      - APP_DATABASE_PORT=5432
-      - APP_DATABASE_NAME=armory
       - REDIS_HOST=redis
-      - REDIS_PORT=6379
       - MANAGED_DATASTORE_BASE_URL=http://armory:3010/v1/data
-      - POLICY_ENGINE_URLS=http://policy_engine:3010
-      - POLICY_ENGINE_ADMIN_API_KEYS=engine-admin-api-key
+      - POLICY_ENGINE_URLS=http://policy_engine_0:3010,http://policy_engine_1:3010,http://policy_engine_2:3010
+      - POLICY_ENGINE_ADMIN_API_KEYS=engine-admin-api-key,engine-admin-api-key,engine-admin-api-key
     volumes:
       - ./packages:/app/packages
       - ./apps:/app/apps
@@ -68,32 +59,78 @@ services:
       redis:
         condition: service_started
 
-  policy_engine:
+  policy_engine_0:
     image: armory/local:latest
     build:
       context: ./
       dockerfile: local.dockerfile
-    container_name: policy-engine
+    container_name: policy-engine-0
     command: ['/bin/bash', '-c', 'make policy-engine/db/migrate/deploy && make policy-engine/start/dev']
     ports:
       - '3020:3010'
     networks:
       - armory_stack
     environment:
-      - NODE_ENV=development
-      - PORT=3010
+      - APP_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/engine-0?schema=public
+      - SIGNING_PROTOCOL=mpc
+      - TSM_URL=http://host.docker.internal:8500
+      - TSM_API_KEY=apikey0
+      - TSM_PLAYER_COUNT=3
       - ADMIN_API_KEY=dde1fba05d6b0b1a40f2cd9f480f6dcc37a6980bcff3db54377a46b056dc472c # engine-admin-api-key
-      - APP_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/engine?schema=public
-      - APP_DATABASE_USERNAME=postgres
-      - APP_DATABASE_PASSWORD=postgres
-      - APP_DATABASE_HOST=host.docker.internal
-      - APP_DATABASE_PORT=5432
-      - APP_DATABASE_NAME=engine
-      - APP_UID=local-dev-engine-instance-1
-      - MASTER_PASSWORD=unsafe-local-dev-master-password
-      - RESOURCE_PATH=./apps/policy-engine/src/resource
-      - KEYRING_TYPE=raw
-      - SIGNING_PROTOCOL=simple
+    volumes:
+      - ./packages:/app/packages
+      - ./apps:/app/apps
+    depends_on:
+      postgres:
+        condition: service_healthy
+      armory:
+        condition: service_started
+
+  policy_engine_1:
+    image: armory/local:latest
+    build:
+      context: ./
+      dockerfile: local.dockerfile
+    container_name: policy-engine-1
+    command: ['/bin/bash', '-c', 'make policy-engine/db/migrate/deploy && make policy-engine/start/dev']
+    ports:
+      - '3021:3010'
+    networks:
+      - armory_stack
+    environment:
+      - APP_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/engine-1?schema=public
+      - SIGNING_PROTOCOL=mpc
+      - TSM_URL=http://host.docker.internal:8501
+      - TSM_API_KEY=apikey1
+      - TSM_PLAYER_COUNT=3
+      - ADMIN_API_KEY=dde1fba05d6b0b1a40f2cd9f480f6dcc37a6980bcff3db54377a46b056dc472c # engine-admin-api-key
+    volumes:
+      - ./packages:/app/packages
+      - ./apps:/app/apps
+    depends_on:
+      postgres:
+        condition: service_healthy
+      armory:
+        condition: service_started
+
+  policy_engine_2:
+    image: armory/local:latest
+    build:
+      context: ./
+      dockerfile: local.dockerfile
+    container_name: policy-engine-2
+    command: ['/bin/bash', '-c', 'make policy-engine/db/migrate/deploy && make policy-engine/start/dev']
+    ports:
+      - '3022:3010'
+    networks:
+      - armory_stack
+    environment:
+      - APP_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/engine-2?schema=public
+      - SIGNING_PROTOCOL=mpc
+      - TSM_URL=http://host.docker.internal:8502
+      - TSM_API_KEY=apikey2
+      - TSM_PLAYER_COUNT=3
+      - ADMIN_API_KEY=dde1fba05d6b0b1a40f2cd9f480f6dcc37a6980bcff3db54377a46b056dc472c # engine-admin-api-key
     volumes:
       - ./packages:/app/packages
       - ./apps:/app/apps
@@ -115,40 +152,15 @@ services:
     networks:
       - armory_stack
     environment:
-      - NODE_ENV=development
       - PORT=3010
-      - ADMIN_API_KEY=d4a6b4c1cb71dbdb68a1dd429ad737369f74b9e264b9dfa639258753987caaad # vault-admin-api-key
       - APP_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/vault?schema=public
-      - APP_DATABASE_USERNAME=postgres
-      - APP_DATABASE_PASSWORD=postgres
-      - APP_DATABASE_HOST=host.docker.internal
-      - APP_DATABASE_PORT=5432
-      - APP_DATABASE_NAME=vault
-      - APP_UID=local-dev-vault-instance-1
-      - MASTER_PASSWORD=unsafe-local-dev-master-password
-      - KEYRING_TYPE=raw
-      - BASE_URL=http://localhost:3011
+      - ADMIN_API_KEY=d4a6b4c1cb71dbdb68a1dd429ad737369f74b9e264b9dfa639258753987caaad # vault-admin-api-key
     volumes:
       - ./packages:/app/packages
       - ./apps:/app/apps
     depends_on:
       postgres:
         condition: service_healthy
-
-  devtool:
-    image: armory/local:latest
-    build:
-      context: ./
-      dockerfile: local.dockerfile
-    container_name: devtool
-    command: ['/bin/bash', '-c', 'make devtool/start/dev']
-    ports:
-      - '4200:4200'
-    networks:
-      - armory_stack
-    volumes:
-      - ./packages:/app/packages
-      - ./apps:/app/apps
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Helps streamline local setup.
You can run `make setup`, `make docker/stack/build`, then `make docker/stack/up` and get the full stack live, can go to devtool (now included in compose file) and start using it.