### PR TITLE
Armory now supports multiple datastore keys; engine already supported.

### DIFF
--- a/apps/armory/Makefile
+++ b/apps/armory/Makefile
@@ -72,7 +72,8 @@ armory/db/create-migration:
 	npx dotenv -e ${ARMORY_PROJECT_DIR}/.env -- \
 		prisma migrate dev \
 			--schema ${ARMORY_DATABASE_SCHEMA} \
-			--name ${NAME}
+			--name ${NAME} \
+			--create-only
 
 # To maintain seed data within their respective modules and then import them
 # into the main seed.ts file for execution, it's necessary to compile the

--- a/apps/armory/src/client/core/service/client.service.ts
+++ b/apps/armory/src/client/core/service/client.service.ts
@@ -46,8 +46,8 @@ export class ClientService {
       dataSecret: null,
       name: input.name,
       dataStore: {
-        entityPublicKey: entityDataStore.keys[0],
-        policyPublicKey: policyDataStore.keys[0]
+        entityPublicKeys: entityDataStore.keys,
+        policyPublicKeys: policyDataStore.keys
       },
       policyEngine: { nodes: [] },
       createdAt: now,
@@ -77,6 +77,9 @@ export class ClientService {
     client.policyEngine = { nodes }
 
     const createdClient = await this.clientRepository.save(client)
+
+    // Trigger a cluster data sync, since we likely _just_ created the datastore.
+    await this.clusterService.sync(clientId)
 
     return {
       ...this.buildPublicClient({

--- a/apps/armory/src/client/core/type/client.type.ts
+++ b/apps/armory/src/client/core/type/client.type.ts
@@ -33,8 +33,8 @@ export const Client = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   dataStore: z.object({
-    entityPublicKey: jwkSchema,
-    policyPublicKey: jwkSchema
+    entityPublicKeys: z.array(jwkSchema).min(1),
+    policyPublicKeys: z.array(jwkSchema).min(1)
   }),
   policyEngine: z.object({
     nodes: z.array(PolicyEngineNode)

--- a/apps/armory/src/managed-data-store/__test__/e2e/data-store.spec.ts
+++ b/apps/armory/src/managed-data-store/__test__/e2e/data-store.spec.ts
@@ -107,8 +107,8 @@ describe('Data Store', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       dataStore: {
-        entityPublicKey: getPublicKey(dataStorePrivateKey),
-        policyPublicKey: getPublicKey(dataStorePrivateKey)
+        entityPublicKeys: [getPublicKey(dataStorePrivateKey)],
+        policyPublicKeys: [getPublicKey(dataStorePrivateKey)]
       },
       policyEngine: {
         nodes: [

--- a/apps/armory/src/managed-data-store/core/service/entity-data-store.service.ts
+++ b/apps/armory/src/managed-data-store/core/service/entity-data-store.service.ts
@@ -1,5 +1,4 @@
 import { EntityStore } from '@narval/policy-engine-shared'
-import { publicKeySchema } from '@narval/signature'
 import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common'
 import { ClientService } from '../../../client/core/service/client.service'
 import { ClusterService } from '../../../policy-engine/core/service/cluster.service'
@@ -10,7 +9,7 @@ import { SignatureService } from './signature.service'
 @Injectable()
 export class EntityDataStoreService extends SignatureService {
   constructor(
-    private entitydataStoreRepository: EntityDataStoreRepository,
+    private entityDataStoreRepository: EntityDataStoreRepository,
     private clientService: ClientService,
     private clusterService: ClusterService
   ) {
@@ -18,7 +17,7 @@ export class EntityDataStoreService extends SignatureService {
   }
 
   async getEntities(clientId: string): Promise<EntityStore | null> {
-    const entityStore = await this.entitydataStoreRepository.getLatestDataStore(clientId)
+    const entityStore = await this.entityDataStoreRepository.getLatestDataStore(clientId)
 
     return entityStore ? EntityStore.parse(entityStore.data) : null
   }
@@ -33,15 +32,15 @@ export class EntityDataStoreService extends SignatureService {
       })
     }
 
-    const latestDataStore = await this.entitydataStoreRepository.getLatestDataStore(clientId)
+    const latestDataStore = await this.entityDataStoreRepository.getLatestDataStore(clientId)
 
     await this.verifySignature({
       payload,
-      pubKey: publicKeySchema.parse(client.dataStore.entityPublicKey),
+      keys: client.dataStore.entityPublicKeys,
       date: latestDataStore?.createdAt
     })
 
-    const { data, version } = await this.entitydataStoreRepository.setDataStore(clientId, {
+    const { data, version } = await this.entityDataStoreRepository.setDataStore(clientId, {
       version: latestDataStore?.version ? latestDataStore.version + 1 : 1,
       data: EntityStore.parse(payload)
     })

--- a/apps/armory/src/managed-data-store/core/service/policy-data-store.service.ts
+++ b/apps/armory/src/managed-data-store/core/service/policy-data-store.service.ts
@@ -1,5 +1,4 @@
 import { PolicyStore } from '@narval/policy-engine-shared'
-import { publicKeySchema } from '@narval/signature'
 import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common'
 import { ClientService } from '../../../client/core/service/client.service'
 import { ClusterService } from '../../../policy-engine/core/service/cluster.service'
@@ -36,7 +35,7 @@ export class PolicyDataStoreService extends SignatureService {
 
     await this.verifySignature({
       payload,
-      pubKey: publicKeySchema.parse(client.dataStore.policyPublicKey),
+      keys: client.dataStore.policyPublicKeys,
       date: latestDataStore?.createdAt
     })
 

--- a/apps/armory/src/managed-data-store/core/service/signature.service.ts
+++ b/apps/armory/src/managed-data-store/core/service/signature.service.ts
@@ -1,30 +1,50 @@
-import { Jwk, Jwt, hash, verifyJwt } from '@narval/signature'
+import { Jwk, Jwt, decodeJwt, hash, verifyJwt } from '@narval/signature'
 import { HttpStatus, Injectable } from '@nestjs/common'
 import { ApplicationException } from '../../../shared/exception/application.exception'
 
 @Injectable()
 export class SignatureService {
-  async verifySignature({
-    pubKey,
-    payload,
-    date
-  }: {
-    pubKey: Jwk
+  async verifySignature(params: {
+    keys: Jwk[]
     payload: { signature: string; data: unknown }
     date: Date | undefined
   }) {
-    let validJwt: Jwt
+    const { keys, payload, date } = params
+    let validJwt: Jwt | undefined
 
-    try {
-      validJwt = await verifyJwt(payload.signature, pubKey)
-    } catch (error) {
+    const jwt = decodeJwt(payload.signature)
+    const jwk = params.keys.find(({ kid }) => kid && kid?.toLowerCase() === jwt.header.kid?.toLowerCase())
+
+    // If we can't find by kid in the header, we'll have to attempt each key in order
+    const pubKeys = jwk ? [jwk] : keys
+
+    const errors = []
+    for (const pubKey of pubKeys) {
+      try {
+        validJwt = await verifyJwt(payload.signature, pubKey)
+        break
+      } catch (error) {
+        errors.push(
+          new ApplicationException({
+            message: error.message,
+            origin: error,
+            suggestedHttpStatusCode: HttpStatus.FORBIDDEN
+          })
+        )
+        continue
+      }
+    }
+
+    // Did not find a valid key for the signature
+    if (!validJwt) {
       throw new ApplicationException({
-        message: error.message,
-        origin: error,
+        message: 'Signature not valid for keys',
+        context: errors,
         suggestedHttpStatusCode: HttpStatus.FORBIDDEN
       })
     }
 
+    // Signature was valid but the data is a mismatch
     if (validJwt.payload.data !== hash(payload.data)) {
       throw new ApplicationException({
         message: 'Signature hash mismatch',
@@ -32,6 +52,7 @@ export class SignatureService {
       })
     }
 
+    // Signature is valid but this data is older than current.
     if (date && validJwt.payload.iat && validJwt.payload.iat < date.getTime() / 1000) {
       throw new ApplicationException({
         message: 'Signature timestamp mismatch',

--- a/apps/armory/src/managed-data-store/shared/guard/__test__/unit/data-store.guard.spec.ts
+++ b/apps/armory/src/managed-data-store/shared/guard/__test__/unit/data-store.guard.spec.ts
@@ -46,8 +46,8 @@ describe(DataStoreGuard.name, () => {
       clientSecret: secret.hash(clientSecret),
       dataSecret: secret.hash(dataSecret),
       dataStore: {
-        entityPublicKey: publicKey,
-        policyPublicKey: publicKey
+        entityPublicKeys: [publicKey],
+        policyPublicKeys: [publicKey]
       },
       policyEngine: {
         nodes: [

--- a/apps/armory/src/orchestration/__test__/e2e/authorization-request.spec.ts
+++ b/apps/armory/src/orchestration/__test__/e2e/authorization-request.spec.ts
@@ -42,8 +42,6 @@ describe('Authorization Request', () => {
     dataSecret: secret.hash('test-data-secret'),
     name: 'Test Evaluation',
     enginePublicKey: {},
-    entityPublicKey: FIXTURE.EOA_CREDENTIAL.Root.key,
-    policyPublicKey: FIXTURE.EOA_CREDENTIAL.Root.key,
     createdAt: new Date(),
     updatedAt: new Date()
   }
@@ -89,8 +87,18 @@ describe('Authorization Request', () => {
       data: {
         ...client,
         enginePublicKey: client.enginePublicKey as Prisma.InputJsonValue,
-        policyPublicKey: client.policyPublicKey as Prisma.InputJsonValue,
-        entityPublicKey: client.entityPublicKey as Prisma.InputJsonValue
+        dataStoreKeys: {
+          create: [
+            {
+              storeType: 'entity',
+              publicKey: FIXTURE.EOA_CREDENTIAL.Root.key as Prisma.InputJsonValue
+            },
+            {
+              storeType: 'policy',
+              publicKey: FIXTURE.EOA_CREDENTIAL.Root.key as Prisma.InputJsonValue
+            }
+          ]
+        }
       }
     })
   })

--- a/apps/armory/src/orchestration/persistence/repository/__test__/integration/authorization-request.repository.spec.ts
+++ b/apps/armory/src/orchestration/persistence/repository/__test__/integration/authorization-request.repository.spec.ts
@@ -27,8 +27,6 @@ describe(AuthorizationRequestRepository.name, () => {
     dataSecret: secret.hash('test-data-secret'),
     name: 'Test Client',
     enginePublicKey: {},
-    entityPublicKey: FIXTURE.EOA_CREDENTIAL.Root.key,
-    policyPublicKey: FIXTURE.EOA_CREDENTIAL.Root.key,
     createdAt: new Date(),
     updatedAt: new Date()
   }
@@ -74,8 +72,18 @@ describe(AuthorizationRequestRepository.name, () => {
       data: {
         ...client,
         enginePublicKey: client.enginePublicKey as Prisma.InputJsonValue,
-        policyPublicKey: client.policyPublicKey as Prisma.InputJsonValue,
-        entityPublicKey: client.entityPublicKey as Prisma.InputJsonValue
+        dataStoreKeys: {
+          create: [
+            {
+              storeType: 'entity',
+              publicKey: FIXTURE.EOA_CREDENTIAL.Root.key as Prisma.InputJsonValue
+            },
+            {
+              storeType: 'policy',
+              publicKey: FIXTURE.EOA_CREDENTIAL.Root.key as Prisma.InputJsonValue
+            }
+          ]
+        }
       }
     })
   })

--- a/apps/armory/src/orchestration/queue/consumer/__test__/integration/authorization-request-processing.consumer.spec.ts
+++ b/apps/armory/src/orchestration/queue/consumer/__test__/integration/authorization-request-processing.consumer.spec.ts
@@ -52,8 +52,6 @@ describe(AuthorizationRequestProcessingConsumer.name, () => {
     dataSecret: secret.hash('test-data-secret'),
     name: 'Test Client',
     enginePublicKey: {},
-    entityPublicKey: FIXTURE.EOA_CREDENTIAL.Root.key,
-    policyPublicKey: FIXTURE.EOA_CREDENTIAL.Root.key,
     createdAt: new Date(),
     updatedAt: new Date()
   }
@@ -139,8 +137,18 @@ describe(AuthorizationRequestProcessingConsumer.name, () => {
       data: {
         ...client,
         enginePublicKey: client.enginePublicKey as Prisma.InputJsonValue,
-        policyPublicKey: client.policyPublicKey as Prisma.InputJsonValue,
-        entityPublicKey: client.entityPublicKey as Prisma.InputJsonValue
+        dataStoreKeys: {
+          create: [
+            {
+              storeType: 'entity',
+              publicKey: FIXTURE.EOA_CREDENTIAL.Root.key as Prisma.InputJsonValue
+            },
+            {
+              storeType: 'policy',
+              publicKey: FIXTURE.EOA_CREDENTIAL.Root.key as Prisma.InputJsonValue
+            }
+          ]
+        }
       }
     })
     await repository.create(authzRequest)

--- a/apps/armory/src/shared/guard/__test__/unit/client-secret.guard.spec.ts
+++ b/apps/armory/src/shared/guard/__test__/unit/client-secret.guard.spec.ts
@@ -34,8 +34,8 @@ describe(ClientSecretGuard.name, () => {
       clientSecret: secret.hash(clientSecret),
       dataSecret: secret.hash(dataSecret),
       dataStore: {
-        entityPublicKey: publicKey,
-        policyPublicKey: publicKey
+        entityPublicKeys: [publicKey],
+        policyPublicKeys: [publicKey]
       },
       policyEngine: {
         nodes: [

--- a/apps/armory/src/shared/module/persistence/schema/migrations/20240815203402_add_data_store_table/migration.sql
+++ b/apps/armory/src/shared/module/persistence/schema/migrations/20240815203402_add_data_store_table/migration.sql
@@ -1,0 +1,64 @@
+-- AlterTable
+ALTER TABLE "client" ALTER COLUMN "entity_public_key" DROP NOT NULL,
+ALTER COLUMN "policy_public_key" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "data_store_key" (
+    "id" VARCHAR(255) NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "store_type" TEXT NOT NULL,
+    "public_key" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "data_store_key_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "data_store_key" ADD CONSTRAINT "data_store_key_client_id_fkey" FOREIGN KEY ("client_id") REFERENCES "client"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+
+--
+-- MANUAL MIGRATION EDITS
+--
+
+-- Copy existing engine public keys into the client table; this fixes a bug that initially wrote the entityDatakey into this column.
+UPDATE client
+SET engine_public_key = (
+    SELECT pub_key
+    FROM engine
+    WHERE engine.client_id = client.id
+    LIMIT 1
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM engine
+    WHERE engine.client_id = client.id
+);
+
+-- Copy existing data keys into the data_store_key table
+-- ... existing code ...
+
+-- Copy existing data keys into the data_store_key table
+INSERT INTO data_store_key (id, client_id, store_type, public_key, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    id,
+    'entity',
+    entity_public_key,
+    created_at,
+    updated_at
+FROM client
+WHERE entity_public_key IS NOT NULL AND entity_public_key != 'null'::jsonb;
+
+INSERT INTO data_store_key (id, client_id, store_type, public_key, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    id,
+    'policy',
+    policy_public_key,
+    created_at,
+    updated_at
+FROM client
+WHERE policy_public_key IS NOT NULL AND policy_public_key != 'null'::jsonb;

--- a/apps/armory/src/shared/module/persistence/schema/schema.prisma
+++ b/apps/armory/src/shared/module/persistence/schema/schema.prisma
@@ -27,12 +27,28 @@ model Client {
   clientSecret    String   @map("client_secret")
   dataSecret      String?  @map("data_secret")
   enginePublicKey Json     @map("engine_public_key")
-  entityPublicKey Json     @map("entity_public_key")
-  policyPublicKey Json     @map("policy_public_key")
+  entityPublicKey Json?    @map("entity_public_key") @ignore // deprecated 15-08-2024 @mattschoch, use dataStoreKeys instead
+  policyPublicKey Json?    @map("policy_public_key") @ignore // deprecated 15-08-2024 @mattschoch, use dataStoreKeys instead
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @default(now()) @updatedAt @map("updated_at")
 
+  dataStoreKeys DataStoreKey[]
+
   @@map("client")
+}
+
+model DataStoreKey {
+  id        String    @id @default(uuid()) @db.VarChar(255)
+  clientId  String    @map("client_id")
+  storeType String    @map("store_type") // entity or policy
+  publicKey Json      @map("public_key") // JWK of the public key
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @default(now()) @updatedAt @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  client Client @relation(fields: [clientId], references: [id])
+
+  @@map("data_store_key")
 }
 
 model Engine {

--- a/apps/armory/src/shared/module/persistence/seed.ts
+++ b/apps/armory/src/shared/module/persistence/seed.ts
@@ -16,8 +16,6 @@ const clients: Client[] = [
     clientSecret: secret.hash('client-secret'),
     dataSecret: secret.hash('data-secret'),
     enginePublicKey: {},
-    entityPublicKey: FIXTURE.EOA_CREDENTIAL.Root.key,
-    policyPublicKey: FIXTURE.EOA_CREDENTIAL.Root.key,
     createdAt: now,
     updatedAt: now
   }
@@ -39,8 +37,20 @@ async function main() {
       data: {
         ...client,
         enginePublicKey: client.enginePublicKey as Prisma.InputJsonValue,
-        policyPublicKey: client.policyPublicKey as Prisma.InputJsonValue,
-        entityPublicKey: client.entityPublicKey as Prisma.InputJsonValue
+        dataStoreKeys: {
+          createMany: {
+            data: [
+              {
+                storeType: 'policy',
+                publicKey: FIXTURE.EOA_CREDENTIAL.Root.key as Prisma.InputJsonValue
+              },
+              {
+                storeType: 'entity',
+                publicKey: FIXTURE.EOA_CREDENTIAL.Root.key as Prisma.InputJsonValue
+              }
+            ]
+          }
+        }
       }
     })
   }

--- a/apps/policy-engine/Makefile
+++ b/apps/policy-engine/Makefile
@@ -81,7 +81,8 @@ policy-engine/db/create-migration:
 	npx dotenv -e ${POLICY_ENGINE_PROJECT_DIR}/.env -- \
 		prisma migrate dev \
 			--schema ${POLICY_ENGINE_DATABASE_SCHEMA} \
-			--name ${NAME}
+			--name ${NAME} \
+			--create-only
 
 policy-engine/db/seed:
 	npx dotenv -e ${POLICY_ENGINE_PROJECT_DIR}/.env -- \

--- a/apps/policy-engine/src/engine/core/service/client.service.ts
+++ b/apps/policy-engine/src/engine/core/service/client.service.ts
@@ -40,7 +40,6 @@ export class ClientService {
 
     // For MPC, we need a unique sessionId; we'll just generate it from the data
     // since this isn't tx signing so it happens just once
-    // TODO: Blockdaemon SessionID must not be longer than 28 characters
     const sessionId = hash(input)
     const keypair = await this.signingService.generateKey(keyId, sessionId)
     const signer = {
@@ -48,17 +47,20 @@ export class ClientService {
       ...keypair
     }
 
-    const client = await this.save({
-      clientId,
-      clientSecret,
-      dataStore: {
-        entity: entityDataStore,
-        policy: policyDataStore
+    const client = await this.save(
+      {
+        clientId,
+        clientSecret,
+        dataStore: {
+          entity: entityDataStore,
+          policy: policyDataStore
+        },
+        signer,
+        createdAt: now,
+        updatedAt: now
       },
-      signer,
-      createdAt: now,
-      updatedAt: now
-    })
+      { syncAfter: false } // new clients often won't have data stores configured yet, so require a manual sync after creation.
+    )
 
     return {
       ...client,

--- a/apps/policy-engine/src/engine/core/service/data-store.service.ts
+++ b/apps/policy-engine/src/engine/core/service/data-store.service.ts
@@ -46,6 +46,13 @@ export class DataStoreService {
     const validation = EntityUtil.validate(entityData.entity.data)
 
     if (validation.success) {
+      if (!entitySignature.entity.signature) {
+        throw new DataStoreException({
+          message: 'Entity data is unsigned',
+          suggestedHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY
+        })
+      }
+
       const signatureVerification = await this.verifySignature({
         data: entityData.entity.data,
         signature: entitySignature.entity.signature,
@@ -77,6 +84,13 @@ export class DataStoreService {
       this.fetchBySource(store.data, PolicyData),
       this.fetchBySource(store.signature, PolicySignature)
     ])
+
+    if (!policySignature.policy.signature) {
+      throw new DataStoreException({
+        message: 'Policy data is unsigned',
+        suggestedHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY
+      })
+    }
 
     const signatureVerification = await this.verifySignature({
       data: policyData.policy.data,

--- a/apps/vault/Makefile
+++ b/apps/vault/Makefile
@@ -70,7 +70,8 @@ vault/db/create-migration:
 	npx dotenv -e ${VAULT_PROJECT_DIR}/.env -- \
 		prisma migrate dev \
 			--schema ${VAULT_DATABASE_SCHEMA} \
-			--name ${NAME}
+			--name ${NAME} \
+			--create-only
 
 vault/db/seed:
 	npx dotenv -e ${VAULT_PROJECT_DIR}/.env -- \

--- a/packages/policy-engine-shared/src/lib/type/data-store.type.ts
+++ b/packages/policy-engine-shared/src/lib/type/data-store.type.ts
@@ -30,12 +30,7 @@ export type Source = z.infer<typeof Source>
 export const DataStoreConfiguration = z.object({
   data: Source,
   signature: Source,
-  // NOTE: Limit the maximum size of the keys because the client creation in
-  // the AS takes the first key and saves it in the database. If the maximum
-  // amount changes, we must ensure the AS takes it into consideration.
-  // See
-  // - The `save` method in the apps/armory/src/client/core/service/client.service.ts
-  keys: z.array(jwkSchema).min(1).max(1)
+  keys: z.array(jwkSchema).min(1)
 })
 export type DataStoreConfiguration = z.infer<typeof DataStoreConfiguration>
 


### PR DESCRIPTION
The Policy Engine was built to support an array of dataStore keys for policy & entity data verification. The expectation is it can use a jwks (jwk set), which is useful for multiple signers & key rotation (eventually, we'll add jwks endpoint support in case you dont' want to pin keys)

Armory cut a corner originally & didn't normalize it's data model & thus made a one-key restriction.
**This removes that restriction**.

Armory now supports an array of data keys just like the engine.

- Database migration includes data patch to update the new table
- Database migration also fixes a data bug writing the wrong key to a column; it's not used so no impact, but this cleans it up.

This PR is in preparation of allowing the Engine to act as the datastore signer, so it can automate approval of data changes & updates to the dataset.