### PR TITLE
allowSelfSignedData on createClient for engine-signed datastores

### DIFF
--- a/apps/armory/src/client/core/service/client.service.ts
+++ b/apps/armory/src/client/core/service/client.service.ts
@@ -71,10 +71,17 @@ export class ClientService {
       clientId,
       nodes: input.policyEngineNodes || this.getDefaultPolicyEngineNodes(),
       entityDataStore,
-      policyDataStore
+      policyDataStore,
+      allowSelfSignedData: input.dataStore.allowSelfSignedData
     })
 
     client.policyEngine = { nodes }
+
+    // If we configured engine to include it's own key in the datastore signers, then we will track that here as well.
+    if (input.dataStore.allowSelfSignedData) {
+      client.dataStore.entityPublicKeys.push(nodes[0].publicKey)
+      client.dataStore.policyPublicKeys.push(nodes[0].publicKey)
+    }
 
     const createdClient = await this.clientRepository.save(client)
 

--- a/apps/armory/src/client/core/type/client.type.ts
+++ b/apps/armory/src/client/core/type/client.type.ts
@@ -19,7 +19,12 @@ export const CreateClientInput = z.object({
   clientSecret: z.string().min(1).optional(),
   dataStore: z.object({
     entity: DataStoreConfiguration,
-    policy: DataStoreConfiguration
+    policy: DataStoreConfiguration,
+    allowSelfSignedData: z
+      .boolean()
+      .default(false)
+      .optional()
+      .describe('Whether to include the engine key in the entity and policy keys')
   }),
   policyEngineNodes: z.array(z.string()).optional()
 })

--- a/apps/armory/src/policy-engine/core/service/__test__/integration/cluster.service.spec.ts
+++ b/apps/armory/src/policy-engine/core/service/__test__/integration/cluster.service.spec.ts
@@ -99,7 +99,8 @@ describe(ClusterService.name, () => {
         clientId,
         nodes: [nodeUrl],
         entityDataStore: dataStoreConfig,
-        policyDataStore: dataStoreConfig
+        policyDataStore: dataStoreConfig,
+        allowSelfSignedData: false
       })
 
       expect(node).toEqual({
@@ -118,7 +119,8 @@ describe(ClusterService.name, () => {
         clientId,
         nodes: [nodeUrl],
         entityDataStore: dataStoreConfig,
-        policyDataStore: dataStoreConfig
+        policyDataStore: dataStoreConfig,
+        allowSelfSignedData: false
       })
 
       const nodes = await policyEngineNodeRepository.findByUrl(nodeUrl)

--- a/apps/armory/src/policy-engine/core/service/cluster.service.ts
+++ b/apps/armory/src/policy-engine/core/service/cluster.service.ts
@@ -40,7 +40,8 @@ export class ClusterService {
     const data = {
       clientId: input.clientId,
       entityDataStore: input.entityDataStore,
-      policyDataStore: input.policyDataStore
+      policyDataStore: input.policyDataStore,
+      allowSelfSignedData: input.allowSelfSignedData
     }
 
     // TODO: (@wcalderipe, 15/05/24): Add retry on failure.

--- a/apps/armory/src/policy-engine/core/type/cluster.type.ts
+++ b/apps/armory/src/policy-engine/core/type/cluster.type.ts
@@ -23,6 +23,7 @@ export const CreatePolicyEngineCluster = z.object({
   clientId: z.string(),
   nodes: z.array(z.string().url()).min(1),
   entityDataStore: DataStoreConfiguration,
-  policyDataStore: DataStoreConfiguration
+  policyDataStore: DataStoreConfiguration,
+  allowSelfSignedData: z.boolean().optional()
 })
 export type CreatePolicyEngineCluster = z.infer<typeof CreatePolicyEngineCluster>

--- a/apps/devtool/src/app/_hooks/useAuthServerApi.tsx
+++ b/apps/devtool/src/app/_hooks/useAuthServerApi.tsx
@@ -30,6 +30,7 @@ export interface AuthClientData {
   entityPublicKey: string
   policyDataStoreUrl: string
   policyPublicKey: string
+  allowSelfSignedData: boolean
 }
 
 const useAuthServerApi = () => {
@@ -80,7 +81,8 @@ const useAuthServerApi = () => {
         entityDataStoreUrl,
         entityPublicKey,
         policyDataStoreUrl,
-        policyPublicKey
+        policyPublicKey,
+        allowSelfSignedData
       } = authClientData
 
       const authAdminClient = new AuthAdminClient({
@@ -114,7 +116,8 @@ const useAuthServerApi = () => {
               url: policyDataStoreUrl
             },
             keys: [JSON.parse(policyPublicKey)]
-          }
+          },
+          allowSelfSignedData
         }
       })
 

--- a/apps/devtool/src/app/config/_components/auth-server/AddAuthClientModal.tsx
+++ b/apps/devtool/src/app/config/_components/auth-server/AddAuthClientModal.tsx
@@ -26,6 +26,7 @@ const initForm: AuthClientData = {
   id: '',
   name: '',
   useManagedDataStore: true,
+  allowSelfSignedData: true,
   entityDataStoreUrl: '',
   entityPublicKey: '',
   policyDataStoreUrl: '',
@@ -150,6 +151,11 @@ const AddAuthClientModal = () => {
                   policyDataStoreUrl: initPolicyDataStoreUrl(form.id, useManagedDataStore)
                 })
               }
+            />
+            <NarCheckbox
+              label="Allow Engine to self-sign data store"
+              checked={form.allowSelfSignedData}
+              onCheckedChange={(allowSelfSignedData) => updateForm({ allowSelfSignedData })}
             />
             <div className="flex gap-[24px]">
               <div className="flex flex-col gap-[8px] w-1/2">

--- a/apps/policy-engine/src/engine/http/rest/controller/client.controller.ts
+++ b/apps/policy-engine/src/engine/http/rest/controller/client.controller.ts
@@ -30,7 +30,8 @@ export class ClientController {
       clientSecret: body.clientSecret,
       unsafeKeyId: body.keyId,
       entityDataStore: body.entityDataStore,
-      policyDataStore: body.policyDataStore
+      policyDataStore: body.policyDataStore,
+      allowSelfSignedData: body.allowSelfSignedData
     })
 
     return CreateClientResponseDto.create(client)

--- a/apps/policy-engine/src/engine/http/rest/dto/create-client.dto.ts
+++ b/apps/policy-engine/src/engine/http/rest/dto/create-client.dto.ts
@@ -1,5 +1,5 @@
+import { CreateClient, PublicClient } from '@narval/policy-engine-shared'
 import { createZodDto } from 'nestjs-zod'
-import { CreateClient, PublicClient } from '../../../../shared/type/domain.type'
 
 export class CreateClientRequestDto extends createZodDto(CreateClient) {}
 

--- a/apps/policy-engine/src/engine/persistence/repository/__test__/integration/http-data-store.repository.spec.ts
+++ b/apps/policy-engine/src/engine/persistence/repository/__test__/integration/http-data-store.repository.spec.ts
@@ -41,7 +41,7 @@ describe(HttpDataStoreRepository.name, () => {
     })
 
     it('throws a DataStoreException when it fails to fetch', async () => {
-      nock(dataStoreHost).get(dataStoreEndpoint).reply(HttpStatus.INTERNAL_SERVER_ERROR, {})
+      nock(dataStoreHost).get(dataStoreEndpoint).times(4).reply(HttpStatus.INTERNAL_SERVER_ERROR, {})
 
       await expect(() => repository.fetch(source)).rejects.toThrow(DataStoreException)
     })

--- a/apps/policy-engine/src/shared/type/domain.type.ts
+++ b/apps/policy-engine/src/shared/type/domain.type.ts
@@ -34,23 +34,3 @@ export const Engine = z.object({
   masterKey: z.string().min(1).optional()
 })
 export type Engine = z.infer<typeof Engine>
-
-export const PublicClient = Client.extend({
-  signer: z.object({
-    publicKey: publicKeySchema
-  })
-})
-export type PublicClient = z.infer<typeof PublicClient>
-
-export const CreateClient = z.object({
-  clientId: z.string().optional(),
-  clientSecret: z
-    .string()
-    .min(1)
-    .optional()
-    .describe('a secret to be used to authenticate the client, sha256 hex-encoded. If null, will be generated.'), // can be generated with `echo -n "my-api-key" | openssl dgst -sha256 | awk '{print $2}'`
-  keyId: z.string().optional().describe('A unique identifier for key that will be used to sign JWTs'),
-  entityDataStore: DataStoreConfiguration,
-  policyDataStore: DataStoreConfiguration
-})
-export type CreateClient = z.infer<typeof CreateClient>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@narval/source",
-  "version": "v0.0.5",
+  "version": "v0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@narval/source",
-      "version": "v0.0.5",
+      "version": "v0.0.11",
       "license": "MPL-2.0",
       "workspaces": [
         "packages/*"
@@ -1797,25 +1797,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz",
-      "integrity": "sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-remap-async-to-generator": "^7.18.9",
-        "@babel/plugin-syntax-async-generators": "^7.8.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-class-properties": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
@@ -1866,23 +1847,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz",
-      "integrity": "sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
@@ -1892,60 +1856,6 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-numeric-separator": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.18.6.tgz",
-      "integrity": "sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
-      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.20.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
-      "integrity": "sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -14183,24 +14093,23 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-13.6.9.tgz",
-      "integrity": "sha512-hFJL4cgLPxncJJd/epQ4dHnMg5Jy/7Q56jFvA3MHViuKpzzfTCJCB+pGY54maZbtym53UJON9WTGpM3S81UfjQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-14.0.0.tgz",
+      "integrity": "sha512-KwMKJB5jsDxqOhT8CGJ55BADDAYxlYDHv5R/ASQlEcdBEZxT0zZmnL0iiq2VqzETUy+Y/Nop+XDFgqyoQm0C2w==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-clean": "13.6.9",
-        "@react-native-community/cli-config": "13.6.9",
-        "@react-native-community/cli-debugger-ui": "13.6.9",
-        "@react-native-community/cli-doctor": "13.6.9",
-        "@react-native-community/cli-hermes": "13.6.9",
-        "@react-native-community/cli-server-api": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
-        "@react-native-community/cli-types": "13.6.9",
+        "@react-native-community/cli-clean": "14.0.0",
+        "@react-native-community/cli-config": "14.0.0",
+        "@react-native-community/cli-debugger-ui": "14.0.0",
+        "@react-native-community/cli-doctor": "14.0.0",
+        "@react-native-community/cli-server-api": "14.0.0",
+        "@react-native-community/cli-tools": "14.0.0",
+        "@react-native-community/cli-types": "14.0.0",
         "chalk": "^4.1.2",
         "commander": "^9.4.1",
         "deepmerge": "^4.3.0",
         "execa": "^5.0.0",
-        "find-up": "^4.1.0",
+        "find-up": "^5.0.0",
         "fs-extra": "^8.1.0",
         "graceful-fs": "^4.1.3",
         "prompts": "^2.4.2",
@@ -14214,12 +14123,12 @@
       }
     },
     "node_modules/@react-native-community/cli-clean": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-13.6.9.tgz",
-      "integrity": "sha512-7Dj5+4p9JggxuVNOjPbduZBAP1SUgNhLKVw5noBUzT/3ZpUZkDM+RCSwyoyg8xKWoE4OrdUAXwAFlMcFDPKykA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-14.0.0.tgz",
+      "integrity": "sha512-kvHthZTNur/wLLx8WL5Oh+r04zzzFAX16r8xuaLhu9qGTE6Th1JevbsIuiQb5IJqD8G/uZDKgIZ2a0/lONcbJg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "13.6.9",
+        "@react-native-community/cli-tools": "14.0.0",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-glob": "^3.3.2"
@@ -14312,14 +14221,14 @@
       }
     },
     "node_modules/@react-native-community/cli-config": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-13.6.9.tgz",
-      "integrity": "sha512-rFfVBcNojcMm+KKHE/xqpqXg8HoKl4EC7bFHUrahMJ+y/tZll55+oX/PGG37rzB8QzP2UbMQ19DYQKC1G7kXeg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-14.0.0.tgz",
+      "integrity": "sha512-2Nr8KR+dgn1z+HLxT8piguQ1SoEzgKJnOPQKE1uakxWaRFcQ4LOXgzpIAscYwDW6jmQxdNqqbg2cRUoOS7IMtQ==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "13.6.9",
+        "@react-native-community/cli-tools": "14.0.0",
         "chalk": "^4.1.2",
-        "cosmiconfig": "^5.1.0",
+        "cosmiconfig": "^9.0.0",
         "deepmerge": "^4.3.0",
         "fast-glob": "^3.3.2",
         "joi": "^17.2.1"
@@ -14338,15 +14247,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "peer": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/@react-native-community/cli-config/node_modules/chalk": {
@@ -14384,18 +14284,29 @@
       "peer": true
     },
     "node_modules/@react-native-community/cli-config/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "peer": true,
       "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-community/cli-config/node_modules/fast-glob": {
@@ -14423,60 +14334,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-config/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-      "peer": true,
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "peer": true,
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "peer": true
-    },
     "node_modules/@react-native-community/cli-config/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14490,31 +14347,30 @@
       }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.6.9.tgz",
-      "integrity": "sha512-TkN7IdFmGPPvTpAo3nCAH9uwGCPxWBEAwpqEZDrq0NWllI7Tdie8vDpGdrcuCcKalmhq6OYnkXzeBah7O1Ztpw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-14.0.0.tgz",
+      "integrity": "sha512-JpfzILfU7eKE9+7AMCAwNJv70H4tJGVv3ZGFqSVoK1YHg5QkVEGsHtoNW8AsqZRS6Fj4os+Fmh+r+z1L36sPmg==",
       "peer": true,
       "dependencies": {
         "serve-static": "^1.13.1"
       }
     },
     "node_modules/@react-native-community/cli-doctor": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-13.6.9.tgz",
-      "integrity": "sha512-5quFaLdWFQB+677GXh5dGU9I5eg2z6Vg4jOX9vKnc9IffwyIFAyJfCZHrxLSRPDGNXD7biDQUdoezXYGwb6P/A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-14.0.0.tgz",
+      "integrity": "sha512-in6jylHjaPUaDzV+JtUblh8m9JYIHGjHOf6Xn57hrmE5Zwzwuueoe9rSMHF1P0mtDgRKrWPzAJVejElddfptWA==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-config": "13.6.9",
-        "@react-native-community/cli-platform-android": "13.6.9",
-        "@react-native-community/cli-platform-apple": "13.6.9",
-        "@react-native-community/cli-platform-ios": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
+        "@react-native-community/cli-config": "14.0.0",
+        "@react-native-community/cli-platform-android": "14.0.0",
+        "@react-native-community/cli-platform-apple": "14.0.0",
+        "@react-native-community/cli-platform-ios": "14.0.0",
+        "@react-native-community/cli-tools": "14.0.0",
         "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "deepmerge": "^4.3.0",
-        "envinfo": "^7.10.0",
+        "envinfo": "^7.13.0",
         "execa": "^5.0.0",
-        "hermes-profile-transformer": "^0.0.6",
         "node-stream-zip": "^1.9.1",
         "ora": "^5.4.1",
         "semver": "^7.5.2",
@@ -14673,95 +14529,13 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@react-native-community/cli-hermes": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-13.6.9.tgz",
-      "integrity": "sha512-GvwiwgvFw4Ws+krg2+gYj8sR3g05evmNjAHkKIKMkDTJjZ8EdyxbkifRUs1ZCq3TMZy2oeblZBXCJVOH4W7ZbA==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-platform-android": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
-        "chalk": "^4.1.2",
-        "hermes-profile-transformer": "^0.0.6"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-13.6.9.tgz",
-      "integrity": "sha512-9KsYGdr08QhdvT3Ht7e8phQB3gDX9Fs427NJe0xnoBh+PDPTI2BD5ks5ttsH8CzEw8/P6H8tJCHq6hf2nxd9cw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-14.0.0.tgz",
+      "integrity": "sha512-nt7yVz3pGKQXnVa5MAk7zR+1n41kNKD3Hi2OgybH5tVShMBo7JQoL2ZVVH6/y/9wAwI/s7hXJgzf1OIP3sMq+Q==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "13.6.9",
+        "@react-native-community/cli-tools": "14.0.0",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-glob": "^3.3.2",
@@ -14856,16 +14630,16 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-apple": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-13.6.9.tgz",
-      "integrity": "sha512-KoeIHfhxMhKXZPXmhQdl6EE+jGKWwoO9jUVWgBvibpVmsNjo7woaG/tfJMEWfWF3najX1EkQAoJWpCDBMYWtlA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-14.0.0.tgz",
+      "integrity": "sha512-WniJL8vR4MeIsjqio2hiWWuUYUJEL3/9TDL5aXNwG68hH3tYgK3742+X9C+vRzdjTmf5IKc/a6PwLsdplFeiwQ==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "13.6.9",
+        "@react-native-community/cli-tools": "14.0.0",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-glob": "^3.3.2",
-        "fast-xml-parser": "^4.0.12",
+        "fast-xml-parser": "^4.2.4",
         "ora": "^5.4.1"
       }
     },
@@ -14979,29 +14753,29 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.6.9.tgz",
-      "integrity": "sha512-CiUcHlGs8vE0CAB4oi1f+dzniqfGuhWPNrDvae2nm8dewlahTBwIcK5CawyGezjcJoeQhjBflh9vloska+nlnw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-14.0.0.tgz",
+      "integrity": "sha512-8kxGv7mZ5nGMtueQDq+ndu08f0ikf3Zsqm3Ix8FY5KCXpSgP14uZloO2GlOImq/zFESij+oMhCkZJGggpWpfAw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-platform-apple": "13.6.9"
+        "@react-native-community/cli-platform-apple": "14.0.0"
       }
     },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-13.6.9.tgz",
-      "integrity": "sha512-W8FSlCPWymO+tlQfM3E0JmM8Oei5HZsIk5S0COOl0MRi8h0NmHI4WSTF2GCfbFZkcr2VI/fRsocoN8Au4EZAug==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-14.0.0.tgz",
+      "integrity": "sha512-A0FIsj0QCcDl1rswaVlChICoNbfN+mkrKB5e1ab5tOYeZMMyCHqvU+eFvAvXjHUlIvVI+LbqCkf4IEdQ6H/2AQ==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
+        "@react-native-community/cli-debugger-ui": "14.0.0",
+        "@react-native-community/cli-tools": "14.0.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.1",
         "nocache": "^3.0.1",
         "pretty-format": "^26.6.2",
         "serve-static": "^1.13.1",
-        "ws": "^6.2.2"
+        "ws": "^6.2.3"
       }
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/@jest/types": {
@@ -15124,9 +14898,9 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-13.6.9.tgz",
-      "integrity": "sha512-OXaSjoN0mZVw3nrAwcY1PC0uMfyTd9fz7Cy06dh+EJc+h0wikABsVRzV8cIOPrVV+PPEEXE0DBrH20T2puZzgQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-14.0.0.tgz",
+      "integrity": "sha512-L7GX5hyYYv0ZWbAyIQKzhHuShnwDqlKYB0tqn57wa5riGCaxYuRPTK+u4qy+WRCye7+i8M4Xj6oQtSd4z0T9cA==",
       "peer": true,
       "dependencies": {
         "appdirsjs": "^1.2.4",
@@ -15134,7 +14908,6 @@
         "execa": "^5.0.0",
         "find-up": "^5.0.0",
         "mime": "^2.4.1",
-        "node-fetch": "^2.6.0",
         "open": "^6.2.0",
         "ora": "^5.4.1",
         "semver": "^7.5.2",
@@ -15327,9 +15100,9 @@
       }
     },
     "node_modules/@react-native-community/cli-types": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-13.6.9.tgz",
-      "integrity": "sha512-RLxDppvRxXfs3hxceW/mShi+6o5yS+kFPnPqZTaMKKR5aSg7LwDpLQW4K2D22irEG8e6RKDkZUeH9aL3vO2O0w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-14.0.0.tgz",
+      "integrity": "sha512-CMUevd1pOWqvmvutkUiyQT2lNmMHUzSW7NKc1xvHgg39NjbS58Eh2pMzIUP85IwbYNeocfYc3PH19vA/8LnQtg==",
       "peer": true,
       "dependencies": {
         "joi": "^17.2.1"
@@ -15393,6 +15166,22 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/@react-native-community/cli/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@react-native-community/cli/node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -15423,6 +15212,36 @@
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native-community/cli/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@react-native-community/cli/node_modules/semver": {
@@ -15459,58 +15278,59 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.87.tgz",
-      "integrity": "sha512-1XmRhqQchN+pXPKEKYdpJlwESxVomJOxtEnIkbo7GAlaN2sym84fHEGDXAjLilih5GVPpcpSmFzTy8jx3LtaFg==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.75.1.tgz",
+      "integrity": "sha512-mrW6dvueJgP5v5mR/dxvW9v+t9AmzR5OMDMq94reT04QarREGGDHEOW5sLzj4uT6Xhqtda2+ZQOaEZ6PPcv+QA==",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.87.tgz",
-      "integrity": "sha512-+vJYpMnENFrwtgvDfUj+CtVJRJuUnzAUYT0/Pb68Sq9RfcZ5xdcCuUgyf7JO+akW2VTBoJY427wkcxU30qrWWw==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.75.1.tgz",
+      "integrity": "sha512-M7CxPAYZVDeBCCyC4BToEf6vPFtZ5EAA5F2fcm0RuErWMNiB2ycD7nCSVpZtQXOxgNItNi+7mRFTLKTNb7AFrQ==",
       "peer": true,
       "dependencies": {
-        "@react-native/codegen": "0.74.87"
+        "@react-native/codegen": "0.75.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.87.tgz",
-      "integrity": "sha512-hyKpfqzN2nxZmYYJ0tQIHG99FQO0OWXp/gVggAfEUgiT+yNKas1C60LuofUsK7cd+2o9jrpqgqW4WzEDZoBlTg==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.75.1.tgz",
+      "integrity": "sha512-u5+7PCkz9J5XKhUwDSJCxLyt49L9qirlBvOR8IwztWVhrf+gd/iIgQLZm9vf/j9tfLhEsgvMup6FMha2/u1cQw==",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.18.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
-        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.0",
         "@babel/plugin-syntax-export-default-from": "^7.0.0",
         "@babel/plugin-syntax-flow": "^7.18.0",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
         "@babel/plugin-syntax-optional-chaining": "^7.0.0",
         "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-generator-functions": "^7.24.3",
         "@babel/plugin-transform-async-to-generator": "^7.20.0",
         "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-class-properties": "^7.24.1",
         "@babel/plugin-transform-classes": "^7.0.0",
         "@babel/plugin-transform-computed-properties": "^7.0.0",
         "@babel/plugin-transform-destructuring": "^7.20.0",
         "@babel/plugin-transform-flow-strip-types": "^7.20.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
         "@babel/plugin-transform-function-name": "^7.0.0",
         "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.24.1",
         "@babel/plugin-transform-modules-commonjs": "^7.0.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.1",
+        "@babel/plugin-transform-numeric-separator": "^7.24.1",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.5",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.1",
+        "@babel/plugin-transform-optional-chaining": "^7.24.5",
         "@babel/plugin-transform-parameters": "^7.0.0",
         "@babel/plugin-transform-private-methods": "^7.22.5",
         "@babel/plugin-transform-private-property-in-object": "^7.22.11",
@@ -15518,6 +15338,7 @@
         "@babel/plugin-transform-react-jsx": "^7.0.0",
         "@babel/plugin-transform-react-jsx-self": "^7.0.0",
         "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+        "@babel/plugin-transform-regenerator": "^7.20.0",
         "@babel/plugin-transform-runtime": "^7.0.0",
         "@babel/plugin-transform-shorthand-properties": "^7.0.0",
         "@babel/plugin-transform-spread": "^7.0.0",
@@ -15525,7 +15346,7 @@
         "@babel/plugin-transform-typescript": "^7.5.0",
         "@babel/plugin-transform-unicode-regex": "^7.0.0",
         "@babel/template": "^7.0.0",
-        "@react-native/babel-plugin-codegen": "0.74.87",
+        "@react-native/babel-plugin-codegen": "0.75.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
       },
@@ -15537,14 +15358,14 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.87.tgz",
-      "integrity": "sha512-GMSYDiD+86zLKgMMgz9z0k6FxmRn+z6cimYZKkucW4soGbxWsbjUAZoZ56sJwt2FJ3XVRgXCrnOCgXoH/Bkhcg==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.75.1.tgz",
+      "integrity": "sha512-nO5CQuXTPL8iou9EzkUjOrGsiano3hGC80AwFlFt8h7q8Bked293YaB3qRQRwN4gmedR8ZKVZGI/pyuvuOWLfQ==",
       "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.0",
         "glob": "^7.1.1",
-        "hermes-parser": "0.19.1",
+        "hermes-parser": "0.22.0",
         "invariant": "^2.2.4",
         "jscodeshift": "^0.14.0",
         "mkdirp": "^0.5.1",
@@ -15558,15 +15379,15 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.74.87.tgz",
-      "integrity": "sha512-EgJG9lSr8x3X67dHQKQvU6EkO+3ksVlJHYIVv6U/AmW9dN80BEFxgYbSJ7icXS4wri7m4kHdgeq2PQ7/3vvrTQ==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.75.1.tgz",
+      "integrity": "sha512-G0GPvFAVrC9k0MfwnKXimaYKqOlEzXFMZ6DmZi2zxSGPFt/MV3sSRjbv3yb8q0mLcK78/J7w1DyImcSQopOCLg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-server-api": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
-        "@react-native/dev-middleware": "0.74.87",
-        "@react-native/metro-babel-transformer": "0.74.87",
+        "@react-native-community/cli-server-api": "14.0.0-alpha.11",
+        "@react-native-community/cli-tools": "14.0.0-alpha.11",
+        "@react-native/dev-middleware": "0.75.1",
+        "@react-native/metro-babel-transformer": "0.75.1",
         "chalk": "^4.0.0",
         "execa": "^5.1.1",
         "metro": "^0.80.3",
@@ -15578,6 +15399,75 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@jest/types": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native-community/cli-debugger-ui": {
+      "version": "14.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-14.0.0-alpha.11.tgz",
+      "integrity": "sha512-0wCNQxhCniyjyMXgR1qXliY180y/2QbvoiYpp2MleGQADr5M1b8lgI4GoyADh5kE+kX3VL0ssjgyxpmbpCD86A==",
+      "peer": true,
+      "dependencies": {
+        "serve-static": "^1.13.1"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native-community/cli-server-api": {
+      "version": "14.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-14.0.0-alpha.11.tgz",
+      "integrity": "sha512-I7YeYI7S5wSxnQAqeG8LNqhT99FojiGIk87DU0vTp6U8hIMLcA90fUuBAyJY38AuQZ12ZJpGa8ObkhIhWzGkvg==",
+      "peer": true,
+      "dependencies": {
+        "@react-native-community/cli-debugger-ui": "14.0.0-alpha.11",
+        "@react-native-community/cli-tools": "14.0.0-alpha.11",
+        "compression": "^1.7.1",
+        "connect": "^3.6.5",
+        "errorhandler": "^1.5.1",
+        "nocache": "^3.0.1",
+        "pretty-format": "^26.6.2",
+        "serve-static": "^1.13.1",
+        "ws": "^6.2.3"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native-community/cli-tools": {
+      "version": "14.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-14.0.0-alpha.11.tgz",
+      "integrity": "sha512-HQCfVnX9aqRdKdLxmQy4fUAUo+YhNGlBV7ZjOayPbuEGWJ4RN+vSy0Cawk7epo7hXd6vKzc7P7y3HlU6Kxs7+w==",
+      "peer": true,
+      "dependencies": {
+        "appdirsjs": "^1.2.4",
+        "chalk": "^4.1.2",
+        "execa": "^5.0.0",
+        "find-up": "^5.0.0",
+        "mime": "^2.4.1",
+        "open": "^6.2.0",
+        "ora": "^5.4.1",
+        "semver": "^7.5.2",
+        "shell-quote": "^1.7.3",
+        "sudo-prompt": "^9.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@types/yargs": {
+      "version": "15.0.19",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
+      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
+      "peer": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/ansi-styles": {
@@ -15629,6 +15519,22 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "peer": true
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@react-native/community-cli-plugin/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -15636,6 +15542,119 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "peer": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "peer": true,
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/pretty-format": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/supports-color": {
@@ -15650,25 +15669,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "peer": true,
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.74.87.tgz",
-      "integrity": "sha512-MN95DJLYTv4EqJc+9JajA3AJZSBYJz2QEJ3uWlHrOky2vKrbbRVaW1ityTmaZa2OXIvNc6CZwSRSE7xCoHbXhQ==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.75.1.tgz",
+      "integrity": "sha512-N+awwEYZHj9lR4hieBK2oFB6C0qa4/6NPpzeqvtLnZddr38H6Wv9CHxSFA8pqIBu4qmn4JcRjOjVD6pXCcLohA==",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.74.87.tgz",
-      "integrity": "sha512-7TmZ3hTHwooYgIHqc/z87BMe1ryrIqAUi+AF7vsD+EHCGxHFdMjSpf1BZ2SUPXuLnF2cTiTfV2RwhbPzx0tYIA==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.75.1.tgz",
+      "integrity": "sha512-2vBIqNe5p/j3ZfDtV3R74OlwoGTgJVDhx9bMIK1U8ODqic+8OVjqvQKGNB+KUb/+HiPkKAhpAIsgcEmL/Nq1sg==",
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.74.87",
-        "@rnx-kit/chromium-edge-launcher": "^1.0.0",
+        "@react-native/debugger-frontend": "0.75.1",
         "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
         "debug": "^2.2.0",
         "node-fetch": "^2.2.0",
@@ -15676,7 +15704,6 @@
         "open": "^7.0.3",
         "selfsigned": "^2.4.1",
         "serve-static": "^1.13.1",
-        "temp-dir": "^2.0.0",
         "ws": "^6.2.2"
       },
       "engines": {
@@ -15724,32 +15751,32 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.74.87.tgz",
-      "integrity": "sha512-T+VX0N1qP+U9V4oAtn7FTX7pfsoVkd1ocyw9swYXgJqU2fK7hC9famW7b3s3ZiufPGPr1VPJe2TVGtSopBjL6A==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.75.1.tgz",
+      "integrity": "sha512-a2gVjX3MB9TF9QZSKje79n1GDAnseTU94VIcFH/4DS3KjbK3yrNXsu1maxGZxDUAKmTUH7Rz4An/Rb5nkZG7dw==",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.74.87.tgz",
-      "integrity": "sha512-M5Evdn76CuVEF0GsaXiGi95CBZ4IWubHqwXxV9vG9CC9kq0PSkoM2Pn7Lx7dgyp4vT7ccJ8a3IwHbe+5KJRnpw==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.75.1.tgz",
+      "integrity": "sha512-7yUCDtsNaIoOefI3M1XiqUaxNQIzNYL0P38IE6JuroVZspPaGmwB34RkgBTuDzNQ+p/4EIgBmqRzqF5Jjlf92A==",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.74.87.tgz",
-      "integrity": "sha512-UsJCO24sNax2NSPBmV1zLEVVNkS88kcgAiYrZHtYSwSjpl4WZ656tIeedBfiySdJ94Hr3kQmBYLipV5zk0NI1A==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.75.1.tgz",
+      "integrity": "sha512-X4NZNWox2E97fJG97XNuTd9wU3FK2c+S/Neg7KsBETPOHUkdoORC3nH1VQRrIqID85yYgdxLxvDwXa9hkmzjuA==",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "@react-native/babel-preset": "0.74.87",
-        "hermes-parser": "0.19.1",
+        "@react-native/babel-preset": "0.75.1",
+        "hermes-parser": "0.22.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -15760,15 +15787,15 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.87.tgz",
-      "integrity": "sha512-Xh7Nyk/MPefkb0Itl5Z+3oOobeG9lfLb7ZOY2DKpFnoCE1TzBmib9vMNdFaLdSxLIP+Ec6icgKtdzYg8QUPYzA==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.75.1.tgz",
+      "integrity": "sha512-TnUII4YFtPBzxA0Eu1RvXrauw+fZlixK6QgbuOZSfhEfgM1ri6O1wse3VaR+h1CJw2NlNjgi902x9uUX8HbH8w==",
       "peer": true
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.87.tgz",
-      "integrity": "sha512-lsGxoFMb0lyK/MiplNKJpD+A1EoEUumkLrCjH4Ht+ZlG8S0BfCxmskLZ6qXn3BiDSkLjfjI/qyZ3pnxNBvkXpQ==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.75.1.tgz",
+      "integrity": "sha512-e7XL9XtU2Z9NUFJFwL9StHa9l2La0/fU7wZ05s8YEMxB+7Fgyn7/X4JsIk7G4xTSPXxPKV2Yz9STHGzKT5OcKQ==",
       "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
@@ -15786,35 +15813,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rnx-kit/chromium-edge-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rnx-kit/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz",
-      "integrity": "sha512-lzD84av1ZQhYUS+jsGqJiCMaJO2dn9u+RTT9n9q6D3SaKVwWqv+7AoRKqBu19bkwyE+iFRl1ymr40QS90jVFYg==",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "^18.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^1.0.0",
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=14.15"
-      }
-    },
-    "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -21113,6 +21111,32 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chromium-edge-launcher": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
+      "integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -23837,6 +23861,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/envinfo": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
@@ -25418,6 +25451,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
+      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
+      "peer": true
+    },
     "node_modules/express": {
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
@@ -25932,9 +25971,9 @@
       "peer": true
     },
     "node_modules/flow-parser": {
-      "version": "0.242.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.242.1.tgz",
-      "integrity": "sha512-E3ml21Q1S5cMAyPbtYslkvI6yZO5oCS/S2EoteeFH8Kx9iKOv/YOJ+dGd/yMf+H3YKfhMKjnOpyNwrO7NdddWA==",
+      "version": "0.243.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.243.0.tgz",
+      "integrity": "sha512-HCDBfH+kZcY5etWYeAqatjW78gkIryzb9XixRsA8lGI1uyYc7aCpElkkO4H+KIpoyQMiY0VAZPI4cyac3wQe8w==",
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -27181,30 +27220,18 @@
       }
     },
     "node_modules/hermes-estree": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.19.1.tgz",
-      "integrity": "sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.22.0.tgz",
+      "integrity": "sha512-FLBt5X9OfA8BERUdc6aZS36Xz3rRuB0Y/mfocSADWEJfomc1xfene33GdyAmtTkKTBXTN/EgAy+rjTKkkZJHlw==",
       "peer": true
     },
     "node_modules/hermes-parser": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.19.1.tgz",
-      "integrity": "sha512-Vp+bXzxYJWrpEuJ/vXxUsLnt0+y4q9zyi4zUlkLqD8FKv4LjIfOvP69R/9Lty3dCyKh0E2BU7Eypqr63/rKT/A==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.22.0.tgz",
+      "integrity": "sha512-gn5RfZiEXCsIWsFGsKiykekktUoh0PdFWYocXsUdZIyWSckT6UIyPcyyUIPSR3kpnELWeK3n3ztAse7Mat6PSA==",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.19.1"
-      }
-    },
-    "node_modules/hermes-profile-transformer": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz",
-      "integrity": "sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==",
-      "peer": true,
-      "dependencies": {
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">=8"
+        "hermes-estree": "0.22.0"
       }
     },
     "node_modules/hexoid": {
@@ -27791,9 +27818,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "23.12.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.12.2.tgz",
-      "integrity": "sha512-XIeh5V+bi8SJSWGL3jqbTEBW5oD6rbP5L+E7dVQh1MNTxxYef0x15rhJVcRb7oiuq4jLtgy2SD8eFlf6P2cmqg==",
+      "version": "23.13.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.13.0.tgz",
+      "integrity": "sha512-B+g0/KTKmN3+NeMKPljQxdrih6Q6lyDF5O2e/Ofd0JQsTLojJD/BSTTN04iw6OVc0yBiHeypu5hoBNV6ag44Zw==",
       "funding": [
         {
           "type": "individual",
@@ -33633,9 +33660,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.9.tgz",
-      "integrity": "sha512-Bc57Xf3GO2Xe4UWQsBj/oW6YfLPABEu8jfDVDiNmJvoQW4CO34oDPuYKe4KlXzXhcuNsqOtSxpbjCRRVjhhREg==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.10.tgz",
+      "integrity": "sha512-FDPi0X7wpafmDREXe1lgg3WzETxtXh6Kpq8+IwsG35R2tMyp2kFIqDdshdohuvDt1J/qDARcEPq7V/jElTb1kA==",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -33652,34 +33679,34 @@
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
         "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.20.1",
+        "hermes-parser": "0.23.0",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.6.3",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-cache-key": "0.80.9",
-        "metro-config": "0.80.9",
-        "metro-core": "0.80.9",
-        "metro-file-map": "0.80.9",
-        "metro-resolver": "0.80.9",
-        "metro-runtime": "0.80.9",
-        "metro-source-map": "0.80.9",
-        "metro-symbolicate": "0.80.9",
-        "metro-transform-plugins": "0.80.9",
-        "metro-transform-worker": "0.80.9",
+        "metro-babel-transformer": "0.80.10",
+        "metro-cache": "0.80.10",
+        "metro-cache-key": "0.80.10",
+        "metro-config": "0.80.10",
+        "metro-core": "0.80.10",
+        "metro-file-map": "0.80.10",
+        "metro-resolver": "0.80.10",
+        "metro-runtime": "0.80.10",
+        "metro-source-map": "0.80.10",
+        "metro-symbolicate": "0.80.10",
+        "metro-transform-plugins": "0.80.10",
+        "metro-transform-worker": "0.80.10",
         "mime-types": "^2.1.27",
         "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
-        "rimraf": "^3.0.2",
         "serialize-error": "^2.1.0",
         "source-map": "^0.5.6",
         "strip-ansi": "^6.0.0",
         "throat": "^5.0.0",
-        "ws": "^7.5.1",
+        "ws": "^7.5.10",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -33690,13 +33717,14 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.9.tgz",
-      "integrity": "sha512-d76BSm64KZam1nifRZlNJmtwIgAeZhZG3fi3K+EmPOlrR8rDtBxQHDSN3fSGeNB9CirdTyabTMQCkCup6BXFSQ==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.10.tgz",
+      "integrity": "sha512-GXHueUzgzcazfzORDxDzWS9jVVRV6u+cR6TGvHOfGdfLzJCj7/D0PretLfyq+MwN20twHxLW+BUXkoaB8sCQBg==",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "hermes-parser": "0.20.1",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.23.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -33704,55 +33732,60 @@
       }
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
-      "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.0.tgz",
+      "integrity": "sha512-Rkp0PNLGpORw4ktsttkVbpYJbrYKS3hAnkxu8D9nvQi6LvSbuPa+tYw/t2u3Gjc35lYd/k95YkjqyTcN4zspag==",
       "peer": true
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
-      "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.0.tgz",
+      "integrity": "sha512-xLwM4ylfHGwrm+2qXfO1JT/fnqEDGSnpS/9hQ4VLtqTexSviu2ZpBgz07U8jVtndq67qdb/ps0qvaWDZ3fkTyg==",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.20.1"
+        "hermes-estree": "0.23.0"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.9.tgz",
-      "integrity": "sha512-ujEdSI43QwI+Dj2xuNax8LMo8UgKuXJEdxJkzGPU6iIx42nYa1byQ+aADv/iPh5sh5a//h5FopraW5voXSgm2w==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.10.tgz",
+      "integrity": "sha512-8CBtDJwMguIE5RvV3PU1QtxUG8oSSX54mIuAbRZmcQ0MYiOl9JdrMd4JCBvIyhiZLoSStph425SMyCSnjtJsdA==",
       "peer": true,
       "dependencies": {
-        "metro-core": "0.80.9",
-        "rimraf": "^3.0.2"
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "metro-core": "0.80.10"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.9.tgz",
-      "integrity": "sha512-hRcYGhEiWIdM87hU0fBlcGr+tHDEAT+7LYNCW89p5JhErFt/QaAkVx4fb5bW3YtXGv5BTV7AspWPERoIb99CXg==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.10.tgz",
+      "integrity": "sha512-57qBhO3zQfoU/hP4ZlLW5hVej2jVfBX6B4NcSfMj4LgDPL3YknWg80IJBxzQfjQY/m+fmMLmPy8aUMHzUp/guA==",
       "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-config": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.9.tgz",
-      "integrity": "sha512-28wW7CqS3eJrunRGnsibWldqgwRP9ywBEf7kg+uzUHkSFJNKPM1K3UNSngHmH0EZjomizqQA2Zi6/y6VdZMolg==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.10.tgz",
+      "integrity": "sha512-0GYAw0LkmGbmA81FepKQepL1KU/85Cyv7sAiWm6QWeV6AcVCpsKg6jGLqGHJ0LLPL60rWzA4TV1DQAlzdJAEtA==",
       "peer": true,
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
+        "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.6.3",
-        "metro": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-core": "0.80.9",
-        "metro-runtime": "0.80.9"
+        "metro": "0.80.10",
+        "metro-cache": "0.80.10",
+        "metro-core": "0.80.10",
+        "metro-runtime": "0.80.10"
       },
       "engines": {
         "node": ">=18"
@@ -33837,27 +33870,29 @@
       "peer": true
     },
     "node_modules/metro-core": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.9.tgz",
-      "integrity": "sha512-tbltWQn+XTdULkGdzHIxlxk4SdnKxttvQQV3wpqqFbHDteR4gwCyTR2RyYJvxgU7HELfHtrVbqgqAdlPByUSbg==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.10.tgz",
+      "integrity": "sha512-nwBB6HbpGlNsZMuzxVqxqGIOsn5F3JKpsp8PziS7Z4mV8a/jA1d44mVOgYmDa2q5WlH5iJfRIIhdz24XRNDlLA==",
       "peer": true,
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.80.9"
+        "metro-resolver": "0.80.10"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.9.tgz",
-      "integrity": "sha512-sBUjVtQMHagItJH/wGU9sn3k2u0nrCl0CdR4SFMO1tksXLKbkigyQx4cbpcyPVOAmGTVuy3jyvBlELaGCAhplQ==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.10.tgz",
+      "integrity": "sha512-ytsUq8coneaN7ZCVk1IogojcGhLIbzWyiI2dNmw2nnBgV/0A+M5WaTTgZ6dJEz3dzjObPryDnkqWPvIGLCPtiw==",
       "peer": true,
       "dependencies": {
         "anymatch": "^3.0.3",
         "debug": "^2.2.0",
         "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "invariant": "^2.2.4",
         "jest-worker": "^29.6.3",
@@ -33889,11 +33924,12 @@
       "peer": true
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.9.tgz",
-      "integrity": "sha512-FEeCeFbkvvPuhjixZ1FYrXtO0araTpV6UbcnGgDUpH7s7eR5FG/PiJz3TsuuPP/HwCK19cZtQydcA2QrCw446A==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.10.tgz",
+      "integrity": "sha512-Xyv9pEYpOsAerrld7cSLIcnCCpv8ItwysOmTA+AKf1q4KyE9cxrH2O2SA0FzMCkPzwxzBWmXwHUr+A89BpEM6g==",
       "peer": true,
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
       },
       "engines": {
@@ -33901,38 +33937,43 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.9.tgz",
-      "integrity": "sha512-wAPIjkN59BQN6gocVsAvvpZ1+LQkkqUaswlT++cJafE/e54GoVkMNCmrR4BsgQHr9DknZ5Um/nKueeN7kaEz9w==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.10.tgz",
+      "integrity": "sha512-EYC5CL7f+bSzrqdk1bylKqFNGabfiI5PDctxoPx70jFt89Jz+ThcOscENog8Jb4LEQFG6GkOYlwmPpsi7kx3QA==",
       "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.9.tgz",
-      "integrity": "sha512-8PTVIgrVcyU+X/rVCy/9yxNlvXsBCk5JwwkbAm/Dm+Abo6NBGtNjWF0M1Xo/NWCb4phamNWcD7cHdR91HhbJvg==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.10.tgz",
+      "integrity": "sha512-Xh0N589ZmSIgJYAM+oYwlzTXEHfASZac9TYPCNbvjNTn0EHKqpoJ/+Im5G3MZT4oZzYv4YnvzRtjqS5k0tK94A==",
       "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.0.0"
+        "@babel/runtime": "^7.0.0",
+        "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.9.tgz",
-      "integrity": "sha512-RMn+XS4VTJIwMPOUSj61xlxgBvPeY4G6s5uIn6kt6HB6A/k9ekhr65UkkDD7WzHYs3a9o869qU8tvOZvqeQzgw==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.10.tgz",
+      "integrity": "sha512-EyZswqJW8Uukv/HcQr6K19vkMXW1nzHAZPWJSEyJFKIbgp708QfRZ6vnZGmrtFxeJEaFdNup4bGnu8/mIOYlyA==",
       "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.20.0",
         "@babel/types": "^7.20.0",
+        "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.80.9",
+        "metro-symbolicate": "0.80.10",
         "nullthrows": "^1.1.1",
-        "ob1": "0.80.9",
+        "ob1": "0.80.10",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -33950,13 +33991,14 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.9.tgz",
-      "integrity": "sha512-Ykae12rdqSs98hg41RKEToojuIW85wNdmSe/eHUgMkzbvCFNVgcC0w3dKZEhSsqQOXapXRlLtHkaHLil0UD/EA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.10.tgz",
+      "integrity": "sha512-qAoVUoSxpfZ2DwZV7IdnQGXCSsf2cAUExUcZyuCqGlY5kaWBb0mx2BL/xbMFDJ4wBp3sVvSBPtK/rt4J7a0xBA==",
       "peer": true,
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.80.9",
+        "metro-source-map": "0.80.10",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
@@ -33979,15 +34021,16 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.9.tgz",
-      "integrity": "sha512-UlDk/uc8UdfLNJhPbF3tvwajyuuygBcyp+yBuS/q0z3QSuN/EbLllY3rK8OTD9n4h00qZ/qgxGv/lMFJkwP4vg==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.10.tgz",
+      "integrity": "sha512-leAx9gtA+2MHLsCeWK6XTLBbv2fBnNFu/QiYhWzMq8HsOAP4u1xQAU0tSgPs8+1vYO34Plyn79xTLUtQCRSSUQ==",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.0",
         "@babel/template": "^7.0.0",
         "@babel/traverse": "^7.20.0",
+        "flow-enums-runtime": "^0.0.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -33995,22 +34038,23 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.9.tgz",
-      "integrity": "sha512-c/IrzMUVnI0hSVVit4TXzt3A1GiUltGVlzCmLJWxNrBGHGrJhvgePj38+GXl1Xf4Fd4vx6qLUkKMQ3ux73bFLQ==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.10.tgz",
+      "integrity": "sha512-zNfNLD8Rz99U+JdOTqtF2o7iTjcDMMYdVS90z6+81Tzd2D0lDWVpls7R1hadS6xwM+ymgXFQTjM6V6wFoZaC0g==",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.0",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "metro": "0.80.9",
-        "metro-babel-transformer": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-cache-key": "0.80.9",
-        "metro-minify-terser": "0.80.9",
-        "metro-source-map": "0.80.9",
-        "metro-transform-plugins": "0.80.9",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.80.10",
+        "metro-babel-transformer": "0.80.10",
+        "metro-cache": "0.80.10",
+        "metro-cache-key": "0.80.10",
+        "metro-minify-terser": "0.80.10",
+        "metro-source-map": "0.80.10",
+        "metro-transform-plugins": "0.80.10",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -34097,18 +34141,18 @@
       }
     },
     "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
-      "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.0.tgz",
+      "integrity": "sha512-Rkp0PNLGpORw4ktsttkVbpYJbrYKS3hAnkxu8D9nvQi6LvSbuPa+tYw/t2u3Gjc35lYd/k95YkjqyTcN4zspag==",
       "peer": true
     },
     "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
-      "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.0.tgz",
+      "integrity": "sha512-xLwM4ylfHGwrm+2qXfO1JT/fnqEDGSnpS/9hQ4VLtqTexSviu2ZpBgz07U8jVtndq67qdb/ps0qvaWDZ3fkTyg==",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.20.1"
+        "hermes-estree": "0.23.0"
       }
     },
     "node_modules/metro/node_modules/is-fullwidth-code-point": {
@@ -37039,10 +37083,13 @@
       }
     },
     "node_modules/ob1": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.9.tgz",
-      "integrity": "sha512-v9yOxowkZbxWhKOaaTyLjIm1aLy4ebMNcSn4NYJKOAI/Qv+SkfEfszpLr2GIxsccmb2Y2HA9qtsqiIJ80ucpVA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.10.tgz",
+      "integrity": "sha512-dJHyB0S6JkMorUSfSGcYGkkg9kmq3qDUu3ygZUKIfkr47XOPuG35r2Sk6tbwtHXbdKIXmcMvM8DF2CwgdyaHfQ==",
       "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -39915,22 +39962,22 @@
       }
     },
     "node_modules/react-native": {
-      "version": "0.74.5",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.5.tgz",
-      "integrity": "sha512-Bgg2WvxaGODukJMTZFTZBNMKVaROHLwSb8VAGEdrlvKwfb1hHg/3aXTUICYk7dwgAnb+INbGMwnF8yeAgIUmqw==",
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.75.1.tgz",
+      "integrity": "sha512-6WGjZdqXLEuBWAP+h2WH5a2Nd9jn7KmQ1GYy0Krzkcfvz9vPtKKIUSEjwvi3q+M0UTu3V/ESBaMDfT/GGr3fkg==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
-        "@react-native-community/cli": "13.6.9",
-        "@react-native-community/cli-platform-android": "13.6.9",
-        "@react-native-community/cli-platform-ios": "13.6.9",
-        "@react-native/assets-registry": "0.74.87",
-        "@react-native/codegen": "0.74.87",
-        "@react-native/community-cli-plugin": "0.74.87",
-        "@react-native/gradle-plugin": "0.74.87",
-        "@react-native/js-polyfills": "0.74.87",
-        "@react-native/normalize-colors": "0.74.87",
-        "@react-native/virtualized-lists": "0.74.87",
+        "@react-native-community/cli": "14.0.0",
+        "@react-native-community/cli-platform-android": "14.0.0",
+        "@react-native-community/cli-platform-ios": "14.0.0",
+        "@react-native/assets-registry": "0.75.1",
+        "@react-native/codegen": "0.75.1",
+        "@react-native/community-cli-plugin": "0.75.1",
+        "@react-native/gradle-plugin": "0.75.1",
+        "@react-native/js-polyfills": "0.75.1",
+        "@react-native/normalize-colors": "0.75.1",
+        "@react-native/virtualized-lists": "0.75.1",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -39938,6 +39985,7 @@
         "chalk": "^4.0.0",
         "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
+        "glob": "^7.1.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.6.3",
         "jsc-android": "^250231.0.0",
@@ -39948,11 +39996,11 @@
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
         "promise": "^8.3.0",
-        "react-devtools-core": "^5.0.0",
+        "react-devtools-core": "^5.3.1",
         "react-refresh": "^0.14.0",
-        "react-shallow-renderer": "^16.15.0",
         "regenerator-runtime": "^0.13.2",
         "scheduler": "0.24.0-canary-efb381bbf-20230505",
+        "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
         "ws": "^6.2.2",
@@ -39966,7 +40014,7 @@
       },
       "peerDependencies": {
         "@types/react": "^18.2.6",
-        "react": "18.2.0"
+        "react": "^18.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -40121,6 +40169,18 @@
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-native/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/string-width": {
@@ -40295,19 +40355,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-shallow-renderer": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
-      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "peer": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
@@ -41363,9 +41410,9 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.16.0.tgz",
-      "integrity": "sha512-6ukNTOkN2OvJ8SJRmWionpn39OHOov1rx72kyGDYk60CaGrDfmT8wXYzgKLW9VFk+dVVXlUmWQVvrkRvx/x3Mg==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.16.3.tgz",
+      "integrity": "sha512-hSHy/s4Zk2xibhj9XTCACB+1PqS+CaJxepGNBhKc/OsHRpqvHAUAm5+uZ6kJJbGXn0pb3XqekHjg6JAqPExzqg==",
       "peer": true
     },
     "node_modules/secp256k1": {
@@ -43125,15 +43172,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/temp/node_modules/rimraf": {
@@ -46375,7 +46413,7 @@
     },
     "packages/armory-sdk": {
       "name": "@narval-xyz/armory-sdk",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/curves": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@narval/source",
-  "version": "v0.0.5",
+  "version": "v0.0.11",
   "license": "MPL-2.0",
   "workspaces": [
     "packages/*"

--- a/packages/armory-sdk/package.json
+++ b/packages/armory-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@narval-xyz/armory-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/armory-sdk/src/lib/http/client/auth/api.ts
+++ b/packages/armory-sdk/src/lib/http/client/auth/api.ts
@@ -835,8 +835,85 @@ export interface AuthorizationResponseDtoEvaluationsInner {
      * @type {any}
      * @memberof AuthorizationResponseDtoEvaluationsInner
      */
+    'transactionRequestIntent'?: any;
+    /**
+     * 
+     * @type {AuthorizationResponseDtoEvaluationsInnerApprovalRequirements}
+     * @memberof AuthorizationResponseDtoEvaluationsInner
+     */
+    'approvalRequirements'?: AuthorizationResponseDtoEvaluationsInnerApprovalRequirements;
+    /**
+     * 
+     * @type {any}
+     * @memberof AuthorizationResponseDtoEvaluationsInner
+     */
     'createdAt': any;
 }
+/**
+ * 
+ * @export
+ * @interface AuthorizationResponseDtoEvaluationsInnerApprovalRequirements
+ */
+export interface AuthorizationResponseDtoEvaluationsInnerApprovalRequirements {
+    /**
+     * 
+     * @type {Array<AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner>}
+     * @memberof AuthorizationResponseDtoEvaluationsInnerApprovalRequirements
+     */
+    'required'?: Array<AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner>;
+    /**
+     * 
+     * @type {Array<AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner>}
+     * @memberof AuthorizationResponseDtoEvaluationsInnerApprovalRequirements
+     */
+    'missing'?: Array<AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner>;
+    /**
+     * 
+     * @type {Array<AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner>}
+     * @memberof AuthorizationResponseDtoEvaluationsInnerApprovalRequirements
+     */
+    'satisfied'?: Array<AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner>;
+}
+/**
+ * 
+ * @export
+ * @interface AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner
+ */
+export interface AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner {
+    /**
+     * 
+     * @type {number}
+     * @memberof AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner
+     */
+    'approvalCount': number;
+    /**
+     * The number of requried approvals
+     * @type {string}
+     * @memberof AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner
+     */
+    'approvalEntityType': AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInnerApprovalEntityTypeEnum;
+    /**
+     * List of entities IDs that must satisfy the requirements
+     * @type {Array<string>}
+     * @memberof AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner
+     */
+    'entityIds': Array<string>;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInner
+     */
+    'countPrincipal': boolean;
+}
+
+export const AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInnerApprovalEntityTypeEnum = {
+    User: 'Narval::User',
+    UserRole: 'Narval::UserRole',
+    UserGroup: 'Narval::UserGroup'
+} as const;
+
+export type AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInnerApprovalEntityTypeEnum = typeof AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInnerApprovalEntityTypeEnum[keyof typeof AuthorizationResponseDtoEvaluationsInnerApprovalRequirementsRequiredInnerApprovalEntityTypeEnum];
+
 /**
  * 
  * @export
@@ -898,6 +975,12 @@ export interface CreateClientRequestDtoDataStore {
      * @memberof CreateClientRequestDtoDataStore
      */
     'policy': CreateClientRequestDtoDataStoreEntity;
+    /**
+     * Whether to include the engine key in the entity and policy keys
+     * @type {boolean}
+     * @memberof CreateClientRequestDtoDataStore
+     */
+    'allowSelfSignedData'?: boolean;
 }
 /**
  * 
@@ -1146,16 +1229,16 @@ export interface CreateClientResponseDto {
 export interface CreateClientResponseDtoDataStore {
     /**
      * 
-     * @type {CreateClientRequestDtoDataStoreEntityKeysInner}
+     * @type {Array<CreateClientRequestDtoDataStoreEntityKeysInner>}
      * @memberof CreateClientResponseDtoDataStore
      */
-    'entityPublicKey': CreateClientRequestDtoDataStoreEntityKeysInner;
+    'entityPublicKeys': Array<CreateClientRequestDtoDataStoreEntityKeysInner>;
     /**
      * 
-     * @type {CreateClientRequestDtoDataStoreEntityKeysInner}
+     * @type {Array<CreateClientRequestDtoDataStoreEntityKeysInner>}
      * @memberof CreateClientResponseDtoDataStore
      */
-    'policyPublicKey': CreateClientRequestDtoDataStoreEntityKeysInner;
+    'policyPublicKeys': Array<CreateClientRequestDtoDataStoreEntityKeysInner>;
     /**
      * 
      * @type {string}

--- a/packages/policy-engine-shared/src/lib/type/client.type.ts
+++ b/packages/policy-engine-shared/src/lib/type/client.type.ts
@@ -31,7 +31,18 @@ export type PublicClient = z.infer<typeof PublicClient>
 
 export const CreateClient = z.object({
   clientId: z.string().optional(),
+  clientSecret: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('a secret to be used to authenticate the client, sha256 hex-encoded. If null, will be generated.'), // can be generated with `echo -n "my-api-key" | openssl dgst -sha256 | awk '{print $2}'`
+  keyId: z.string().optional().describe('A unique identifier for key that will be used to sign JWTs'),
   entityDataStore: DataStoreConfiguration,
-  policyDataStore: DataStoreConfiguration
+  policyDataStore: DataStoreConfiguration,
+  allowSelfSignedData: z
+    .boolean()
+    .default(false)
+    .optional()
+    .describe('Whether to include the engine key in the entity and policy keys')
 })
 export type CreateClient = z.infer<typeof CreateClient>


### PR DESCRIPTION
Adds a new config value to Create Client for `allowSelfSignedData`.
If true, the Engine will insert it's own client public key into the policy & entity datastore keys lists, allowing the Engine to sign the data sets.

This PR does not include the actual signing capability, only the configuration for the Engine to trust datasets signed by itself -- a future PR will include the self-signing functionality & policy rules.