### PR TITLE
Bugfix - armory crashes on values > bigint

### DIFF
--- a/apps/armory/src/orchestration/core/service/authorization-request.service.ts
+++ b/apps/armory/src/orchestration/core/service/authorization-request.service.ts
@@ -123,6 +123,19 @@ export class AuthorizationRequestService {
     return this.authzRequestRepository.findById(requestId)
   }
 
+  safeBigInt(value: string | number): bigint {
+    try {
+      return BigInt(value)
+    } catch (error) {
+      throw new ApplicationException({
+        message: 'Invalid BigInt value',
+        context: { value },
+        origin: error,
+        suggestedHttpStatusCode: HttpStatus.BAD_REQUEST
+      })
+    }
+  }
+
   async evaluate(input: AuthorizationRequest): Promise<AuthorizationRequest> {
     this.logger.log('Start authorization request evaluation', {
       requestId: input.id,
@@ -165,7 +178,6 @@ export class AuthorizationRequestService {
             suggestedHttpStatusCode: HttpStatus.BAD_REQUEST
           })
         }
-
         const transfer = {
           resourceId: input.request.resourceId,
           clientId: input.clientId,
@@ -176,7 +188,7 @@ export class AuthorizationRequestService {
           chainId: input.request.transactionRequest.chainId,
           initiatedBy: evaluation.principal?.userId,
           createdAt: new Date(),
-          amount: BigInt(intent.amount),
+          amount: this.safeBigInt(intent.amount),
           rates: transferPrices[intent.token] || {}
         }
 

--- a/apps/armory/src/orchestration/core/service/authorization-request.service.ts
+++ b/apps/armory/src/orchestration/core/service/authorization-request.service.ts
@@ -123,7 +123,7 @@ export class AuthorizationRequestService {
     return this.authzRequestRepository.findById(requestId)
   }
 
-  safeBigInt(value: string | number): bigint {
+  bigIntWithError(value: string | number): bigint {
     try {
       return BigInt(value)
     } catch (error) {
@@ -188,7 +188,7 @@ export class AuthorizationRequestService {
           chainId: input.request.transactionRequest.chainId,
           initiatedBy: evaluation.principal?.userId,
           createdAt: new Date(),
-          amount: this.safeBigInt(intent.amount),
+          amount: this.bigIntWithError(intent.amount),
           rates: transferPrices[intent.token] || {}
         }
 

--- a/apps/armory/src/orchestration/persistence/repository/authorization-request.repository.ts
+++ b/apps/armory/src/orchestration/persistence/repository/authorization-request.repository.ts
@@ -132,8 +132,8 @@ export class AuthorizationRequestRepository {
       return errors.map((error) => ({
         id: error.id,
         clientId,
-        name: error.name,
-        message: error.message
+        name: error.name || 'Unknown error',
+        message: error.message || ''
       }))
     }
 


### PR DESCRIPTION
- Authorization requests are updated with error status
- It expects only authorization Request errors that got a name and a message property
- BigInt(valueTooHigh) throws an error without a name
- Primsa subsequent call to update request with error.name fails, its not thrown and server crashes


Solution:
- Default values for name and message properties
- Catch BigInt error to give proper context