### PR TITLE
Bugfix - checkDestinationClassification shouldn't default to 'managed'

### DIFF
--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/destination_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/destination_test.rego
@@ -22,3 +22,39 @@ test_checkDestinationClassification_on_managed_Account {
 		"assignees": [],
 	}}}
 }
+
+test_checkDestinationClassification_on_no_addressbook_or_account {
+  req = {
+  "action": "signTransaction",
+  "principal": {
+    "userId": "test-antoine-user-uid",
+    "id": "0x6af10b6d5024963972ba832486ea1ae29f1b99cb1191abe444b52e98c69f7487",
+    "key": {
+      "kty": "EC",
+      "alg": "ES256K",
+      "kid": "0x6af10b6d5024963972ba832486ea1ae29f1b99cb1191abe444b52e98c69f7487",
+      "crv": "secp256k1",
+      "x": "QwUuAC2s22VKwoS5uPTZgcTN_ztkwt9VWKRae3bikEQ",
+      "y": "lZgwfE7ZDz9af9_PZxq9B7pVwAarfIaFESATYp-Q7Uk"
+    }
+  },
+  "intent": {
+    "to": "eip155:1:0x1afe44aca4abee6867385dcc7eb36ce4335b59c1",
+    "from": "eip155:1:0x0301e2724a40e934cce3345928b88956901aa127",
+    "type": "transferNative",
+    "amount": "1000000000000000000",
+    "token": "eip155:1/slip44:60"
+  },
+  "transactionRequest": {
+    "chainId": 1,
+    "from": "0x0301e2724a40e934cce3345928b88956901aa127",
+    "to": "0x1afe44aca4abee6867385dcc7eb36ce4335b59c1",
+    "value": "0xde0b6b3a7640000"
+  },
+  "resource": {
+    "uid": "eip155:eoa:0x0301e2724a40e934cce3345928b88956901aa127"
+  }
+}
+
+  not checkDestinationClassification({"managed"}) with input as req with data.entities as entities
+}

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/destination_test.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/__test__/criteria/intent/destination_test.rego
@@ -24,37 +24,35 @@ test_checkDestinationClassification_on_managed_Account {
 }
 
 test_checkDestinationClassification_on_no_addressbook_or_account {
-  req = {
-  "action": "signTransaction",
-  "principal": {
-    "userId": "test-antoine-user-uid",
-    "id": "0x6af10b6d5024963972ba832486ea1ae29f1b99cb1191abe444b52e98c69f7487",
-    "key": {
-      "kty": "EC",
-      "alg": "ES256K",
-      "kid": "0x6af10b6d5024963972ba832486ea1ae29f1b99cb1191abe444b52e98c69f7487",
-      "crv": "secp256k1",
-      "x": "QwUuAC2s22VKwoS5uPTZgcTN_ztkwt9VWKRae3bikEQ",
-      "y": "lZgwfE7ZDz9af9_PZxq9B7pVwAarfIaFESATYp-Q7Uk"
-    }
-  },
-  "intent": {
-    "to": "eip155:1:0x1afe44aca4abee6867385dcc7eb36ce4335b59c1",
-    "from": "eip155:1:0x0301e2724a40e934cce3345928b88956901aa127",
-    "type": "transferNative",
-    "amount": "1000000000000000000",
-    "token": "eip155:1/slip44:60"
-  },
-  "transactionRequest": {
-    "chainId": 1,
-    "from": "0x0301e2724a40e934cce3345928b88956901aa127",
-    "to": "0x1afe44aca4abee6867385dcc7eb36ce4335b59c1",
-    "value": "0xde0b6b3a7640000"
-  },
-  "resource": {
-    "uid": "eip155:eoa:0x0301e2724a40e934cce3345928b88956901aa127"
-  }
-}
+	req = {
+		"action": "signTransaction",
+		"principal": {
+			"userId": "test-antoine-user-uid",
+			"id": "0x6af10b6d5024963972ba832486ea1ae29f1b99cb1191abe444b52e98c69f7487",
+			"key": {
+				"kty": "EC",
+				"alg": "ES256K",
+				"kid": "0x6af10b6d5024963972ba832486ea1ae29f1b99cb1191abe444b52e98c69f7487",
+				"crv": "secp256k1",
+				"x": "QwUuAC2s22VKwoS5uPTZgcTN_ztkwt9VWKRae3bikEQ",
+				"y": "lZgwfE7ZDz9af9_PZxq9B7pVwAarfIaFESATYp-Q7Uk",
+			},
+		},
+		"intent": {
+			"to": "eip155:1:0x1afe44aca4abee6867385dcc7eb36ce4335b59c1",
+			"from": "eip155:1:0x0301e2724a40e934cce3345928b88956901aa127",
+			"type": "transferNative",
+			"amount": "1000000000000000000",
+			"token": "eip155:1/slip44:60",
+		},
+		"transactionRequest": {
+			"chainId": 1,
+			"from": "0x0301e2724a40e934cce3345928b88956901aa127",
+			"to": "0x1afe44aca4abee6867385dcc7eb36ce4335b59c1",
+			"value": "0xde0b6b3a7640000",
+		},
+		"resource": {"uid": "eip155:eoa:0x0301e2724a40e934cce3345928b88956901aa127"},
+	}
 
-  not checkDestinationClassification({"managed"}) with input as req with data.entities as entities
+	not checkDestinationClassification({"managed"}) with input as req with data.entities as entities
 }

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/account.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/account.rego
@@ -45,10 +45,10 @@ getDestination(intent) = entry {
 	not data.entities.addressBook[intent.to]
 
 	chainAccount = parseChainAccount(intent.to)
-  account = data.entities.accounts[_]
-  isAddressEqual(account.address, chainAccount.address) == true
-	
-  chainId = _getChainId(account, chainAccount)
+	account = data.entities.accounts[_]
+	isAddressEqual(account.address, chainAccount.address) == true
+
+	chainId = _getChainId(account, chainAccount)
 
 	# INVARIANT: Every EOA Account is an implicity AddressBook on every chain
 	# which `classification` is always `managed`.

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/account.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/account.rego
@@ -45,10 +45,10 @@ getDestination(intent) = entry {
 	not data.entities.addressBook[intent.to]
 
 	chainAccount = parseChainAccount(intent.to)
-	account = data.entities.accounts[_]
-	isAddressEqual(account.address, chainAccount.address)
-
-	chainId = _getChainId(account, chainAccount)
+  account = data.entities.accounts[_]
+  isAddressEqual(account.address, chainAccount.address) == true
+	
+  chainId = _getChainId(account, chainAccount)
 
 	# INVARIANT: Every EOA Account is an implicity AddressBook on every chain
 	# which `classification` is always `managed`.

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/eth.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/eth.rego
@@ -1,7 +1,5 @@
 package armory.util.eth
 
 isAddressEqual(a, b) = result {
-	lower_a := lower(a)
-	lower_b := lower(b)
-	result := lower_a == lower_b
+	result :=  lower(a) == lower(b)
 }

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/eth.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/eth.rego
@@ -1,3 +1,7 @@
 package armory.util.eth
 
-isAddressEqual(a, b) = {lower(a) == lower(b)}
+isAddressEqual(a, b) = result {
+    lower_a := lower(a)
+    lower_b := lower(b)
+    result := (lower_a == lower_b)
+}

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/eth.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/eth.rego
@@ -1,5 +1,5 @@
 package armory.util.eth
 
 isAddressEqual(a, b) = result {
-	result :=  lower(a) == lower(b)
+	result := lower(a) == lower(b)
 }

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/util/eth.rego
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/util/eth.rego
@@ -1,7 +1,7 @@
 package armory.util.eth
 
 isAddressEqual(a, b) = result {
-    lower_a := lower(a)
-    lower_b := lower(b)
-    result := (lower_a == lower_b)
+	lower_a := lower(a)
+	lower_b := lower(b)
+	result := lower_a == lower_b
 }

--- a/packages/policy-engine-shared/src/lib/schema/policy.schema.ts
+++ b/packages/policy-engine-shared/src/lib/schema/policy.schema.ts
@@ -168,7 +168,6 @@ const rollingTimeWindowSchema = z.object({
   endDate: z.number().int().optional()
 })
 
-
 export const timeWindowSchema = z.discriminatedUnion('type', [rollingTimeWindowSchema, fixedTimeWindowSchema])
 
 export const transferFiltersSchema = z.object({


### PR DESCRIPTION
This PR fixed a bug where the evaluation of checkDestinationClassification did not failed when entities has no 'account' or 'addressBook' entry for the 'to' address.

This was caused by isAddressEqual behavior and usage.

- `isAddressEqual` compares two addresses lowercased, and should return a boolean - it returned a set.
- Calling this function in itself is not enough to make the evaluation fail in rego. You need to compare the result with 'true'.

This PR:
- enforces that the address built from the intent is equal to an address in the entities account, by comparing the result of 'isAddressEqual' with 'true'
- changes 'isAddressEqual' so that it returns a boolean and not a set containing a boolean