### PR TITLE
switch back to OPA official binary

### DIFF
--- a/.github/workflows/policy-engine.yml
+++ b/.github/workflows/policy-engine.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Download and install custom OPA
         run: |
-          curl -L -o opa https://raw.githubusercontent.com/Ptroger/opa-bugfix-build/main/opa_linux_amd64_static
+          curl -L -o opa https://openpolicyagent.org/downloads/v0.69.0/opa_linux_amd64_static
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
 

--- a/deploy/policy-engine.dockerfile
+++ b/deploy/policy-engine.dockerfile
@@ -4,7 +4,7 @@ FROM node:21 as build
 WORKDIR /usr/src/app
 
 # Install the OPA binary, which we'll need to actually run evals
-RUN curl -L -o opa https://raw.githubusercontent.com/Ptroger/opa-bugfix-build/main/opa_linux_amd64_static && \
+RUN curl -L -o opa https://openpolicyagent.org/downloads/v0.69.0/opa_linux_amd64_static && \
     chmod 755 opa && \
     mv opa /usr/local/bin/opa && \
     opa version


### PR DESCRIPTION
OPA released new version with the fix on integer comparison that we implemented locally. So we can stop using our custom build and switch back to the official one