### PR TITLE
Change DevTool port to 3025

### DIFF
--- a/apps/devtool/.env.development
+++ b/apps/devtool/.env.development
@@ -2,5 +2,5 @@ NEXT_PUBLIC_AUTH_SERVER_URL=http://localhost:3005
 NEXT_PUBLIC_ENGINE_SERVER_URL=http://localhost:3010
 NEXT_PUBLIC_VAULT_SERVER_URL=http://localhost:3011
 
-NEXT_PUBLIC_LOCAL_DATA_STORE_URL=http://localhost:4200/api/data-store
+NEXT_PUBLIC_LOCAL_DATA_STORE_URL=http://localhost:3025/api/data-store
 NEXT_PUBLIC_MANAGED_DATASTORE_BASE_URL=http://localhost:3005/data

--- a/apps/devtool/project.json
+++ b/apps/devtool/project.json
@@ -21,7 +21,8 @@
       "defaultConfiguration": "production",
       "options": {
         "buildTarget": "devtool:build",
-        "dev": true
+        "dev": true,
+        "port": 3025
       },
       "configurations": {
         "development": {

--- a/apps/devtool/src/app/_lib/constants.ts
+++ b/apps/devtool/src/app/_lib/constants.ts
@@ -1,5 +1,5 @@
 export const LOCAL_DATA_STORE_URL =
-  process.env.NEXT_PUBLIC_LOCAL_DATA_STORE_URL || 'http://localhost:4200/api/data-store'
+  process.env.NEXT_PUBLIC_LOCAL_DATA_STORE_URL || 'http://localhost:3025/api/data-store'
 export const AUTH_SERVER_URL = process.env.NEXT_PUBLIC_AUTH_SERVER_URL || 'https://auth.armory.narval.xyz'
 export const ENGINE_URL = process.env.NEXT_PUBLIC_ENGINE_SERVER_URL || 'http://localhost:3010'
 export const VAULT_URL = process.env.NEXT_PUBLIC_VAULT_SERVER_URL || 'https://vault.armory.narval.xyz'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,7 @@ services:
     container_name: devtool
     command: ['/bin/bash', '-c', 'make devtool/start/dev']
     ports:
-      - '4200:4200'
+      - '3025:3025'
     networks:
       - armory_stack
     volumes:

--- a/packages/armory-sdk/src/lib/http/policy-engine.ts
+++ b/packages/armory-sdk/src/lib/http/policy-engine.ts
@@ -59,7 +59,7 @@ export const sendEvaluationRequest = async (
     const body = await signRequestPayload({ clientId, jwk, alg, signer }, request)
 
     const { data } = await axios.post<SendEvaluationResponse>(
-      `${engineHost}/evaluations`,
+      `${engineHost}/v1/evaluations`,
       SerializedEvaluationRequest.parse(body),
       { headers: { [HEADER_CLIENT_ID]: clientId } }
     )

--- a/packages/nestjs-shared/src/lib/util/with-api-version.util.ts
+++ b/packages/nestjs-shared/src/lib/util/with-api-version.util.ts
@@ -3,9 +3,11 @@ import { VersionValue } from '@nestjs/common/interfaces'
 
 /**
  * Adds NestJS URI versionning to the application.
+ *
  * IMPORTANT: In order to work with Swagger, this function needs to be called
  * before withSwagger at app boostrap.
- * https://github.com/nestjs/swagger/issues/1495
+ *
+ * @see https://github.com/nestjs/swagger/issues/1495
  *
  * @param app - The INestApplication instance.
  * @returns The modified INestApplication instance.
@@ -15,6 +17,7 @@ export const withApiVersion =
   (params: { defaultVersion: VersionValue }) =>
   (app: INestApplication): INestApplication => {
     app.enableVersioning({
+      ...params,
       type: VersioningType.URI
     })
 


### PR DESCRIPTION
This PR changes the DevTool port to 3025 to keep the stack's applications running in the range of 3xxx. Moreover, it prevents port clash with other Next applications running locally (e.g. Armory Cloud).

- Fix `withApiVersion` function to correct set the default version.
- Fix the Policy Engine's evaluation endpoint in the DevTool.