### PR TITLE
Add logs to track data store execution time

### DIFF
--- a/apps/armory/src/managed-data-store/core/service/entity-data-store.service.ts
+++ b/apps/armory/src/managed-data-store/core/service/entity-data-store.service.ts
@@ -82,7 +82,7 @@ export class EntityDataStoreService extends SignatureService {
       thunk: () => this.clusterService.sync(clientId)
     })
 
-    const entity = this.withExecutionTimeLog({
+    const entity = await this.withExecutionTimeLog({
       clientId,
       id: 'EntityStore.parse',
       thunk: () => EntityStore.parse(data)

--- a/packages/nestjs-shared/src/lib/util/index.ts
+++ b/packages/nestjs-shared/src/lib/util/index.ts
@@ -1,4 +1,5 @@
 export * as coerce from './coerce.util'
+export * as log from './log.util'
 export * as secret from './secret.util'
 
 export * from './with-api-version.util'

--- a/packages/nestjs-shared/src/lib/util/log.util.ts
+++ b/packages/nestjs-shared/src/lib/util/log.util.ts
@@ -1,0 +1,58 @@
+import { LoggerService } from '../module/logger/service/logger.service'
+
+export const startExecutionTimer = (logger: LoggerService, id: string, startContext?: Record<string, unknown>) => {
+  const startTime = new Date().getTime()
+
+  logger.log(`Execution time of ${id} - Start`, {
+    ...(startContext ? { ...startContext } : {}),
+    startTime
+  })
+
+  return {
+    stop: (stopContext?: Record<string, unknown>) => {
+      const stopTime = new Date().getTime()
+      const duration = stopTime - startTime
+
+      logger.log(`Execution time of ${id} - Stop`, {
+        ...(startContext ? { ...startContext } : {}),
+        ...(stopContext ? { ...stopContext } : {}),
+        startTime,
+        stopTime,
+        duration
+      })
+    }
+  }
+}
+
+export const withExecutionTime = <T>({
+  logger,
+  id,
+  startContext,
+  thunk
+}: {
+  logger: LoggerService
+  id: string
+  thunk: () => T | Promise<T>
+  startContext?: Record<string, unknown>
+}): T | Promise<T> => {
+  const timer = startExecutionTimer(logger, id, startContext)
+  const result = thunk()
+
+  if (result instanceof Promise) {
+    return result.then(
+      (value) => {
+        timer.stop()
+
+        return value
+      },
+      (error) => {
+        timer.stop()
+        throw error
+      }
+    )
+  }
+
+  timer.stop()
+
+  return result
+}


### PR DESCRIPTION
This PR adds temporary logs to track execution time of data store while the OpenTelemetry instrumentation isn't ready.

Not pretty but it'll answer quickly how much time we waste on these processes.