### PR TITLE
Temporarily remove Prisma instrumentation

### DIFF
--- a/apps/armory/src/shared/module/persistence/schema/schema.prisma
+++ b/apps/armory/src/shared/module/persistence/schema/schema.prisma
@@ -5,10 +5,6 @@ generator client {
   //
   // Reference: https://github.com/nrwl/nx-recipes/tree/main/nestjs-prisma
   output   = "../../../../../../../node_modules/@prisma/client/armory"
-  // Enable tracing to integrate with OTEL.
-  //
-  // Reference: https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing
-  previewFeatures = ["tracing", "interactiveTransactions"]
 }
 
 datasource db {

--- a/apps/policy-engine/src/shared/module/persistence/schema/schema.prisma
+++ b/apps/policy-engine/src/shared/module/persistence/schema/schema.prisma
@@ -5,10 +5,6 @@ generator client {
   //
   // Reference: https://github.com/nrwl/nx-recipes/tree/main/nestjs-prisma
   output   = "../../../../../../../node_modules/@prisma/client/policy-engine"
-  // Enable tracing to integrate with OTEL.
-  //
-  // Reference: https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing
-  previewFeatures = ["tracing", "interactiveTransactions"]
 }
 
 datasource db {

--- a/apps/vault/src/shared/module/persistence/schema/schema.prisma
+++ b/apps/vault/src/shared/module/persistence/schema/schema.prisma
@@ -6,10 +6,6 @@ generator client {
   //
   // Reference: https://github.com/nrwl/nx-recipes/tree/main/nestjs-prisma
   output   = "../../../../../../../node_modules/@prisma/client/vault"
-  // Enable tracing to integrate with OTEL.
-  //
-  // Reference: https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing
-  previewFeatures = ["tracing", "interactiveTransactions"]
 }
 
 datasource db {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,18 +35,17 @@
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/auto-instrumentations-node": "0.51.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "0.53.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.54.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.54.1",
         "@opentelemetry/exporter-trace-otlp-proto": "0.53.0",
-        "@opentelemetry/instrumentation": "^0.54.1",
-        "@opentelemetry/resources": "^1.27.0",
+        "@opentelemetry/instrumentation": "0.54.1",
+        "@opentelemetry/resources": "1.27.0",
         "@opentelemetry/sdk-metrics": "1.26.0",
         "@opentelemetry/sdk-node": "0.53.0",
-        "@opentelemetry/sdk-trace-base": "^1.27.0",
-        "@opentelemetry/sdk-trace-node": "^1.26.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
         "@opentelemetry/winston-transport": "0.7.0",
         "@prisma/client": "5.22.0",
-        "@prisma/instrumentation": "5.22.0",
         "@radix-ui/react-checkbox": "1.1.1",
         "@radix-ui/react-collapsible": "1.0.3",
         "@radix-ui/react-dialog": "1.0.5",
@@ -16926,49 +16925,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
-      }
-    },
-    "node_modules/@prisma/instrumentation": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
-      "integrity": "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.8",
-        "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0",
-        "@opentelemetry/sdk-trace-base": "^1.22"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
-      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@types/shimmer": "^1.2.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@opentelemetry/semantic-conventions": "1.27.0",
     "@opentelemetry/winston-transport": "0.7.0",
     "@prisma/client": "5.22.0",
-    "@prisma/instrumentation": "5.22.0",
     "@radix-ui/react-checkbox": "1.1.1",
     "@radix-ui/react-collapsible": "1.0.3",
     "@radix-ui/react-dialog": "1.0.5",

--- a/packages/open-telemetry/src/lib/open-telemetry.ts
+++ b/packages/open-telemetry/src/lib/open-telemetry.ts
@@ -20,7 +20,6 @@ import { Resource } from '@opentelemetry/resources'
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
-import { PrismaInstrumentation } from '@prisma/instrumentation'
 
 type OpenTelemetryOption = {
   serviceName: string
@@ -48,7 +47,7 @@ export const buildOpenTelemetrySdk = ({ serviceName, diagLogLevel }: OpenTelemet
     metricReader: new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter()
     }),
-    instrumentations: [...getNodeAutoInstrumentations(), new PrismaInstrumentation()]
+    instrumentations: [getNodeAutoInstrumentations()]
   })
 }
 


### PR DESCRIPTION
This PR temporarily removes Prisma instrumentation to reduce the amount of noise in the cloud deployment failure of the Armory stack right now.

The engine and vault deploy docker images are not working in ArgoCD.