### PR TITLE
Improve instrumentation on Authorization Request jobs

### DIFF
--- a/.github/workflows/armory.yml
+++ b/.github/workflows/armory.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/packages-publish.yml
+++ b/.github/workflows/packages-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: '20'
           registry-url: https://registry.npmjs.org/
           cache: 'npm'
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/policy-engine.yml
+++ b/.github/workflows/policy-engine.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ TERM_GREEN := \033[0;32m
 # === Install ===
 
 install:
-	npm install
+	npm install --engine-strict
 
 install/ci:
-	npm ci
+	npm ci --engine-strict
 
 # === Setup ===
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ dependency `@narval-xyz/armory-mpc-module`.
 
 1. Create a `.npmrc` file in the root of this project.
 1. Get the values from someone who has them.
-1. Now `npm install` should work.
+1. Now `make install` should work.
 
 ## Generating a new project
 
@@ -133,7 +133,7 @@ packages to NPM.
 
 1. Run `make packages/release` and follow the prompts to bump the
    projects' versions.
-1. Run `npm install` to update `package-lock.json`.
+1. Run `make install` to update `package-lock.json`.
 1. Commit and push the changes to your branch.
 1. After your branch is merged, manually trigger the [packages pipeline to
    publish](https://github.com/narval-xyz/armory/actions/workflows/packages-publish.yml)

--- a/apps/armory/src/orchestration/orchestration.constant.ts
+++ b/apps/armory/src/orchestration/orchestration.constant.ts
@@ -81,3 +81,5 @@ export const ACTION_REQUEST = new Map<Action, ActionRequestConfig>([
     }
   ]
 ])
+
+export const OTEL_ATTR_JOB_ID = 'job.id'

--- a/deploy/armory.dockerfile
+++ b/deploy/armory.dockerfile
@@ -1,4 +1,4 @@
-FROM node:21 as build
+FROM node:20 as build
 
 # Set the working directory
 WORKDIR /usr/src/app
@@ -19,7 +19,7 @@ RUN make armory/db/generate-types && \
     make armory/build && \
     rm -rf apps/ && rm -rf packages/
 
-FROM node:21 as final
+FROM node:20 as final
 
 WORKDIR /usr/src/app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,9 @@
         "typescript": "5.4.5",
         "zod-fixture": "2.5.1"
       },
+      "engines": {
+        "node": ">=21.0.0"
+      },
       "optionalDependencies": {
         "@narval-xyz/armory-mpc-module": "0.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,7 @@
         "zod-fixture": "2.5.1"
       },
       "engines": {
-        "node": ">=21.0.0"
+        "node": "^20.0.0"
       },
       "optionalDependencies": {
         "@narval-xyz/armory-mpc-module": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@narval/source",
   "version": "v0.0.13",
   "license": "MPL-2.0",
+  "engines": {
+    "node": ">=21.0.0"
+  },
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "v0.0.13",
   "license": "MPL-2.0",
   "engines": {
-    "node": ">=21.0.0"
+    "node": "^20.0.0"
   },
   "workspaces": [
     "packages/*"

--- a/packages/nestjs-shared/src/lib/module/open-telemetry/service/trace.service.ts
+++ b/packages/nestjs-shared/src/lib/module/open-telemetry/service/trace.service.ts
@@ -5,7 +5,7 @@ export const TraceService = Symbol('TraceService')
 /**
  * OpenTelemetry Trace/Span Name Conventions
  *
- * Format: <operation_type>.<entity>.<action>
+ * Format: `<operation_type>.<entity>.<action>`
  *
  * Common Operation Types:
  * - http: Web operations


### PR DESCRIPTION
This PR adds spans for the authorization request job lifecycle including its ID and metadata. The goal is to have clarity on the authorization request lead time.

This PR also enforces node version 20 across all applications [given a limitation on Vercel](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions).