### PR TITLE
docs: cleanup documents

### DIFF
--- a/apps/docs/docs/contributing/policy-engine-architecture.md
+++ b/apps/docs/docs/contributing/policy-engine-architecture.md
@@ -23,10 +23,10 @@ columns 1
 
 The policy engine is built on the shoulders of the Open Policy Agent (OPA), a
 battle-tested multi purpose engine trusted by many organizations. The OPA core
-bunlded with the policy engine's artifact and it's considered a trusted
+bundled with the policy engine's artifact and it's considered a trusted
 component.
 
-The policy engine layer, is responsible for encrypting and decrypting client
+The policy engine layer is responsible for encrypting and decrypting client
 data it stores. When the engine server starts, it writes data to its storage
 backend. Since the storage backend lives outside the engine, it's considered
 untrusted so the engine will encrypt the data before it sends them to the

--- a/apps/docs/docs/contributing/policy-engine-setup.md
+++ b/apps/docs/docs/contributing/policy-engine-setup.md
@@ -124,7 +124,7 @@ sequenceDiagram
   Engine ->> DS: Fetch client data
   Engine ->> DB: Write CEK (AES-256) client's data
   Note over DB: Does not fail the onboarding if fetching the client data failed
-  Engine -->> Admin: client's UID, sgining public key and TAK
+  Engine -->> Admin: client's UID, signing public key and TAK
   deactivate Engine
 ```
 

--- a/apps/policy-engine/src/resource/open-policy-agent/rego/README.md
+++ b/apps/policy-engine/src/resource/open-policy-agent/rego/README.md
@@ -2,7 +2,7 @@
 
 ## Main
 
-The implementation of engine general logic. This package is the one were transpiled policy are written
+The implementation of engine general logic. This package is the one where transpiled policy are written
 Transpiled policies then use Armory/criteria functions to evaluate input
 
 ## Armory
@@ -26,7 +26,7 @@ Functions used to query loaded data. It serves as a source of truth to know if s
 
 - Enforce invariants like lowercasing hex addresses
 - Aggregate data from multiple places in entity in order to build useful relationships
-- build runtime types that depends on entity data result
+- build runtime types that depend on entity data result
 
 ### Lib
 
@@ -35,7 +35,7 @@ Utils that are not domain specific, like case insensitive comparison or time.
 ### Test_Data
 
 Values that are specifically used by tests.
-**this shouldn't be imported in production code**
+**These shouldn't be imported in production code**
 
 # Tests
 


### PR DESCRIPTION
Fix typos and grammatical errors to make the documentation clearer. Hope this helps.