### PR TITLE
Add provider integration database schema

### DIFF
--- a/apps/armory/Makefile
+++ b/apps/armory/Makefile
@@ -30,13 +30,15 @@ armory/build:
 # === Code format ===
 
 armory/format:
-	 npx nx format:write --projects ${ARMORY_PROJECT_NAME}
+	npx nx format:write --projects ${ARMORY_PROJECT_NAME}
+	npx prisma format --schema ${ARMORY_DATABASE_SCHEMA}
 
 armory/lint:
 	npx nx lint ${ARMORY_PROJECT_NAME} -- --fix
 
 armory/format/check:
-	 npx nx format:check --projects ${ARMORY_PROJECT_NAME}
+	npx nx format:check --projects ${ARMORY_PROJECT_NAME}
+	npx prisma format --schema ${ARMORY_DATABASE_SCHEMA}
 
 armory/lint/check:
 	npx nx lint ${ARMORY_PROJECT_NAME}

--- a/apps/policy-engine/Makefile
+++ b/apps/policy-engine/Makefile
@@ -43,9 +43,11 @@ policy-engine/lint/check:
 
 policy-engine/format:
 	npx nx format:write --projects ${POLICY_ENGINE_PROJECT_NAME}
+	npx prisma format --schema ${POLICY_ENGINE_DATABASE_SCHEMA}
 
 policy-engine/format/check:
 	npx nx format:check --projects ${POLICY_ENGINE_PROJECT_NAME}
+	npx prisma format --schema ${POLICY_ENGINE_DATABASE_SCHEMA}
 
 # === Database ===
 

--- a/apps/policy-engine/src/shared/module/persistence/schema/schema.prisma
+++ b/apps/policy-engine/src/shared/module/persistence/schema/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
 }
 
 model Engine {
-  id          String @id
+  id          String  @id
   masterKey   String? @map("master_key")
   adminApiKey String? @map("admin_api_key")
 

--- a/apps/vault/Makefile
+++ b/apps/vault/Makefile
@@ -30,12 +30,14 @@ vault/build:
 
 vault/format:
 	npx nx format:write --projects ${VAULT_PROJECT_NAME}
+	npx prisma format --schema ${VAULT_DATABASE_SCHEMA}
 
 vault/lint:
 	npx nx lint ${VAULT_PROJECT_NAME} -- --fix
 
 vault/format/check:
 	npx nx format:check --projects ${VAULT_PROJECT_NAME}
+	npx prisma format --schema ${VAULT_DATABASE_SCHEMA}
 
 vault/lint/check:
 	npx nx lint ${VAULT_PROJECT_NAME}

--- a/apps/vault/src/shared/module/persistence/schema/migrations/20241203141912_add_provider_integration_tables/migration.sql
+++ b/apps/vault/src/shared/module/persistence/schema/migrations/20241203141912_add_provider_integration_tables/migration.sql
@@ -1,0 +1,141 @@
+-- CreateTable
+CREATE TABLE "provider_wallet" (
+    "id" TEXT NOT NULL,
+    "label" TEXT,
+    "client_id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "provider_wallet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "provider_account" (
+    "id" TEXT NOT NULL,
+    "label" TEXT,
+    "client_id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "wallet_id" TEXT NOT NULL,
+    "network_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "provider_account_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "provider_address" (
+    "id" TEXT NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "account_id" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "provider_address_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "provider_address_book" (
+    "id" TEXT NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "connection_id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "external_classification" TEXT,
+    "address" TEXT NOT NULL,
+    "asset_id" TEXT,
+    "network_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "provider_address_book_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "provider_connection" (
+    "id" TEXT NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "label" TEXT,
+    "credentials" JSONB NOT NULL,
+    "status" TEXT NOT NULL,
+    "_integrity" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "revoked_at" TIMESTAMP(3),
+
+    CONSTRAINT "provider_connection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "provider_wallet_connection" (
+    "client_id" TEXT NOT NULL,
+    "connection_id" TEXT NOT NULL,
+    "wallet_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "provider_wallet_connection_pkey" PRIMARY KEY ("client_id","connection_id","wallet_id")
+);
+
+-- CreateTable
+CREATE TABLE "provider_sync" (
+    "id" TEXT NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "connection_id" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "error_name" TEXT,
+    "error_message" TEXT,
+    "error_trace_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completed_at" TIMESTAMP(3),
+
+    CONSTRAINT "provider_sync_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "provider_transfer" (
+    "id" TEXT NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "source_wallet_id" TEXT,
+    "source_account_id" TEXT,
+    "source_address_id" TEXT,
+    "provider" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "provider_transfer_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "provider_account" ADD CONSTRAINT "provider_account_wallet_id_fkey" FOREIGN KEY ("wallet_id") REFERENCES "provider_wallet"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "provider_address" ADD CONSTRAINT "provider_address_account_id_fkey" FOREIGN KEY ("account_id") REFERENCES "provider_account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "provider_address_book" ADD CONSTRAINT "provider_address_book_connection_id_fkey" FOREIGN KEY ("connection_id") REFERENCES "provider_connection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "provider_wallet_connection" ADD CONSTRAINT "provider_wallet_connection_connection_id_fkey" FOREIGN KEY ("connection_id") REFERENCES "provider_connection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "provider_wallet_connection" ADD CONSTRAINT "provider_wallet_connection_wallet_id_fkey" FOREIGN KEY ("wallet_id") REFERENCES "provider_wallet"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "provider_sync" ADD CONSTRAINT "provider_sync_connection_id_fkey" FOREIGN KEY ("connection_id") REFERENCES "provider_connection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "provider_transfer" ADD CONSTRAINT "provider_transfer_source_wallet_id_fkey" FOREIGN KEY ("source_wallet_id") REFERENCES "provider_wallet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "provider_transfer" ADD CONSTRAINT "provider_transfer_source_account_id_fkey" FOREIGN KEY ("source_account_id") REFERENCES "provider_account"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "provider_transfer" ADD CONSTRAINT "provider_transfer_source_address_id_fkey" FOREIGN KEY ("source_address_id") REFERENCES "provider_address"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/vault/src/shared/module/persistence/schema/migrations/20241203160823_add_provider_integration_tables/migration.sql
+++ b/apps/vault/src/shared/module/persistence/schema/migrations/20241203160823_add_provider_integration_tables/migration.sql
@@ -41,7 +41,7 @@ CREATE TABLE "provider_address" (
 );
 
 -- CreateTable
-CREATE TABLE "provider_address_book" (
+CREATE TABLE "provider_known_destination" (
     "id" TEXT NOT NULL,
     "client_id" TEXT NOT NULL,
     "connection_id" TEXT NOT NULL,
@@ -54,7 +54,7 @@ CREATE TABLE "provider_address_book" (
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
 
-    CONSTRAINT "provider_address_book_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "provider_known_destination_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -120,7 +120,7 @@ ALTER TABLE "provider_account" ADD CONSTRAINT "provider_account_wallet_id_fkey" 
 ALTER TABLE "provider_address" ADD CONSTRAINT "provider_address_account_id_fkey" FOREIGN KEY ("account_id") REFERENCES "provider_account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "provider_address_book" ADD CONSTRAINT "provider_address_book_connection_id_fkey" FOREIGN KEY ("connection_id") REFERENCES "provider_connection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "provider_known_destination" ADD CONSTRAINT "provider_known_destination_connection_id_fkey" FOREIGN KEY ("connection_id") REFERENCES "provider_connection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "provider_wallet_connection" ADD CONSTRAINT "provider_wallet_connection_connection_id_fkey" FOREIGN KEY ("connection_id") REFERENCES "provider_connection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/vault/src/shared/module/persistence/schema/schema.prisma
+++ b/apps/vault/src/shared/module/persistence/schema/schema.prisma
@@ -1,11 +1,11 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x"]
   // Output into a separate subdirectory so multiple schemas can be used in a
   // monorepo.
   //
   // Reference: https://github.com/nrwl/nx-recipes/tree/main/nestjs-prisma
-  output   = "../../../../../../../node_modules/@prisma/client/vault"
+  output        = "../../../../../../../node_modules/@prisma/client/vault"
 }
 
 datasource db {
@@ -14,7 +14,7 @@ datasource db {
 }
 
 model Vault {
-  id          String @id
+  id          String  @id
   masterKey   String? @map("master_key")
   adminApiKey String? @map("admin_api_key")
 
@@ -24,10 +24,145 @@ model Vault {
 // TODO: (@wcalderipe, 12/03/23) use hstore extension for better performance.
 // See https://www.postgresql.org/docs/9.1/hstore.html
 model KeyValue {
-  key         String @id
-  clientId    String? @map("client_id")
-  collection  String
-  value       String
+  key        String  @id
+  clientId   String? @map("client_id")
+  collection String
+  value      String
 
   @@map("key_value")
+}
+
+model ProviderWallet {
+  id         String   @id
+  label      String?
+  clientId   String   @map("client_id")
+  provider   String
+  externalId String   @map("external_id")
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  accounts    ProviderAccount[]
+  connections ProviderWalletConnection[]
+  transfers   ProviderTransfer[]         @relation("SourceWallet")
+
+  @@map("provider_wallet")
+}
+
+model ProviderAccount {
+  id         String   @id
+  label      String?
+  clientId   String   @map("client_id")
+  provider   String
+  externalId String   @map("external_id")
+  walletId   String   @map("wallet_id")
+  networkId  String   @map("network_id")
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  wallet    ProviderWallet     @relation(fields: [walletId], references: [id])
+  addresses ProviderAddress[]
+  transfers ProviderTransfer[] @relation("SourceAccount")
+
+  @@map("provider_account")
+}
+
+model ProviderAddress {
+  id         String   @id
+  clientId   String   @map("client_id")
+  provider   String
+  externalId String   @map("external_id")
+  accountId  String   @map("account_id")
+  address    String
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  account   ProviderAccount    @relation(fields: [accountId], references: [id])
+  transfers ProviderTransfer[] @relation("SourceAddress")
+
+  @@map("provider_address")
+}
+
+model ProviderAddressBook {
+  id                     String   @id
+  clientId               String   @map("client_id")
+  connectionId           String   @map("connection_id")
+  provider               String
+  externalId             String   @map("external_id")
+  externalClassification String?  @map("external_classification")
+  address                String
+  assetId                String?  @map("asset_id")
+  networkId              String   @map("network_id")
+  createdAt              DateTime @default(now()) @map("created_at")
+  updatedAt              DateTime @updatedAt @map("updated_at")
+
+  connection ProviderConnection @relation(fields: [connectionId], references: [id])
+
+  @@map("provider_address_book")
+}
+
+model ProviderConnection {
+  id          String    @id
+  clientId    String    @map("client_id")
+  provider    String
+  url         String
+  label       String?
+  credentials Json
+  status      String
+  integrity   String    @map("_integrity")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
+  revokedAt   DateTime? @map("revoked_at")
+
+  counterparties ProviderAddressBook[]
+  connections    ProviderWalletConnection[]
+  syncs          ProviderSync[]
+
+  @@map("provider_connection")
+}
+
+model ProviderWalletConnection {
+  clientId     String   @map("client_id")
+  connectionId String   @map("connection_id")
+  walletId     String   @map("wallet_id")
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  connection ProviderConnection @relation(fields: [connectionId], references: [id])
+  wallet     ProviderWallet     @relation(fields: [walletId], references: [id])
+
+  @@id([clientId, connectionId, walletId])
+  @@map("provider_wallet_connection")
+}
+
+model ProviderSync {
+  id           String    @id
+  clientId     String    @map("client_id")
+  connectionId String    @map("connection_id")
+  status       String
+  errorName    String?   @map("error_name")
+  errorMessage String?   @map("error_message")
+  errorTraceId String?   @map("error_trace_id")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  completedAt  DateTime? @map("completed_at")
+
+  // Relations
+  connection ProviderConnection @relation(fields: [connectionId], references: [id])
+
+  @@map("provider_sync")
+}
+
+model ProviderTransfer {
+  id              String   @id
+  clientId        String   @map("client_id")
+  sourceWalletId  String?  @map("source_wallet_id")
+  sourceAccountId String?  @map("source_account_id")
+  sourceAddressId String?  @map("source_address_id")
+  provider        String
+  externalId      String   @map("external_id")
+  createdAt       DateTime @default(now()) @map("created_at")
+
+  wallet  ProviderWallet?  @relation("SourceWallet", fields: [sourceWalletId], references: [id])
+  account ProviderAccount? @relation("SourceAccount", fields: [sourceAccountId], references: [id])
+  address ProviderAddress? @relation("SourceAddress", fields: [sourceAddressId], references: [id])
+
+  @@map("provider_transfer")
 }

--- a/apps/vault/src/shared/module/persistence/schema/schema.prisma
+++ b/apps/vault/src/shared/module/persistence/schema/schema.prisma
@@ -82,7 +82,7 @@ model ProviderAddress {
   @@map("provider_address")
 }
 
-model ProviderAddressBook {
+model ProviderKnownDestination {
   id                     String   @id
   clientId               String   @map("client_id")
   connectionId           String   @map("connection_id")
@@ -97,7 +97,7 @@ model ProviderAddressBook {
 
   connection ProviderConnection @relation(fields: [connectionId], references: [id])
 
-  @@map("provider_address_book")
+  @@map("provider_known_destination")
 }
 
 model ProviderConnection {
@@ -113,9 +113,9 @@ model ProviderConnection {
   updatedAt   DateTime  @updatedAt @map("updated_at")
   revokedAt   DateTime? @map("revoked_at")
 
-  counterparties ProviderAddressBook[]
-  connections    ProviderWalletConnection[]
-  syncs          ProviderSync[]
+  knwonDestinations ProviderKnownDestination[]
+  connections       ProviderWalletConnection[]
+  syncs             ProviderSync[]
 
   @@map("provider_connection")
 }


### PR DESCRIPTION
This PR adds the initial database schema for doing custom provider integrations in the Vault.

It also adds a minor change to the `format` command to also format the Prisma schema to ensure code consistency.

See https://linear.app/narval/issue/NAR-1979