### PR TITLE
Add sdk dependency eddsa

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@nestjs/platform-express": "10.3.9",
         "@nestjs/swagger": "7.4.0",
         "@noble/curves": "1.6.0",
-        "@noble/ed25519": "2.1.0",
+        "@noble/ed25519": "1.7.1",
         "@noble/hashes": "1.4.0",
         "@open-policy-agent/opa-wasm": "1.9.0",
         "@opentelemetry/api": "1.9.0",
@@ -7145,12 +7145,15 @@
       }
     },
     "node_modules/@noble/ed25519": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.1.0.tgz",
-      "integrity": "sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
+      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
@@ -45271,7 +45274,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/curves": "1.6.0",
-        "@noble/ed25519": "2.1.0",
+        "@noble/ed25519": "1.7.1",
         "@noble/hashes": "1.4.0",
         "axios": "1.7.7",
         "jose": "5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@nestjs/platform-express": "10.3.9",
         "@nestjs/swagger": "7.4.0",
         "@noble/curves": "1.6.0",
-        "@noble/ed25519": "1.7.1",
+        "@noble/ed25519": "2.1.0",
         "@noble/hashes": "1.4.0",
         "@open-policy-agent/opa-wasm": "1.9.0",
         "@opentelemetry/api": "1.9.0",
@@ -7145,15 +7145,12 @@
       }
     },
     "node_modules/@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.1.0.tgz",
+      "integrity": "sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
@@ -45270,10 +45267,12 @@
     },
     "packages/armory-sdk": {
       "name": "@narval-xyz/armory-sdk",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/curves": "1.6.0",
+        "@noble/ed25519": "2.1.0",
+        "@noble/hashes": "1.4.0",
         "axios": "1.7.7",
         "jose": "5.5.0",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@nestjs/platform-express": "10.3.9",
     "@nestjs/swagger": "7.4.0",
     "@noble/curves": "1.6.0",
-    "@noble/ed25519": "1.7.1",
+    "@noble/ed25519": "2.1.0",
     "@noble/hashes": "1.4.0",
     "@open-policy-agent/opa-wasm": "1.9.0",
     "@opentelemetry/api": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@nestjs/platform-express": "10.3.9",
     "@nestjs/swagger": "7.4.0",
     "@noble/curves": "1.6.0",
-    "@noble/ed25519": "2.1.0",
+    "@noble/ed25519": "1.7.1",
     "@noble/hashes": "1.4.0",
     "@open-policy-agent/opa-wasm": "1.9.0",
     "@opentelemetry/api": "1.9.0",

--- a/packages/armory-sdk/package.json
+++ b/packages/armory-sdk/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@noble/curves": "1.6.0",
     "@noble/hashes": "1.4.0",
-    "@noble/ed25519": "2.1.0",
+    "@noble/ed25519": "1.7.1",
     "axios": "1.7.7",
     "jose": "5.5.0",
     "lodash": "4.17.21",

--- a/packages/armory-sdk/package.json
+++ b/packages/armory-sdk/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@narval-xyz/armory-sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
     "@noble/curves": "1.6.0",
+    "@noble/hashes": "1.4.0",
+    "@noble/ed25519": "2.1.0",
     "axios": "1.7.7",
     "jose": "5.5.0",
     "lodash": "4.17.21",


### PR DESCRIPTION
This fixes armory-sdk package. It depends on noble/eddsa and noble/hash and they have to be dependencies in the package, not just in the monorepo
