### PR TITLE
bump sdk to version 0.10.0

### DIFF
--- a/packages/armory-sdk/package.json
+++ b/packages/armory-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@narval-xyz/armory-sdk",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bump sdk version before publishing.

In this change, sdk supports new groups and groupsMembership without breaking support for deprecated groups.
